### PR TITLE
Update Gradle Android plugin to 0.8+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
+        classpath 'com.android.tools.build:gradle:0.8.+'
     }
 }
 


### PR DESCRIPTION
Otherwise build fails, at least on my machine:

```
   1
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/moe/Workspaces/android/simpletask-android/build.gradle' line: 12

* What went wrong:
A problem occurred evaluating root project 'simpletask-android'.
> Could not create plugin of type 'AppPlugin'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --debug option to get more log output.

BUILD FAILED
```
