### PR TITLE
Calendar due & threshold date sync

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -24,6 +24,8 @@ You should have received a copy of the GNU General Public License along with Sim
     package="nl.mpcjanssen.simpletask" >
 
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
 
     <supports-screens
             android:anyDensity="true"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -116,6 +116,11 @@ You should have received a copy of the GNU General Public License along with Sim
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.provider.calendar.action.HANDLE_CUSTOM_EVENT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="vnd.android.cursor.item/event" />
+            </intent-filter>
             <meta-data
                     android:name="android.app.searchable"
                     android:resource="@xml/searchable"/>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License along with Sim
 @license http://www.gnu.org/licenses/gpl.html
 @copyright 2009-2012 Todo.txt contributors (http://todotxt.com)
 @copyright 2012-2013  Mark Janssen
+@copyright 2015 Vojtech Kral
 -->
 <!-- package name and version codes are overwritten by Gradle -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"

--- a/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
@@ -71,6 +71,7 @@ public class CalendarSync {
     private ContentResolver m_cr;
     private boolean m_enabled = false;
     private Uri m_cal_uri;
+
     private int m_margin_minutes = 1440;
     private ScheduledThreadPoolExecutor m_stpe;
 
@@ -173,7 +174,7 @@ public class CalendarSync {
         if (!m_enabled) return;
 
         final List<Task> tasks = m_app.getTaskCache().getTasks();
-        m_margin_minutes = m_app.getRemindersMarginDays() * 1440;
+        setRemindersMarginDays(m_app.getRemindersMarginDays());
 
         long calID = getCalID();
         if (calID == -1) {
@@ -220,5 +221,9 @@ public class CalendarSync {
         } else if (!m_enabled && calID != -1) {
             removeCalendar();
         }
+    }
+
+    public void setRemindersMarginDays(int days) {
+        m_margin_minutes = days * 1440 - 720;    // -720 to make the reminder go off during the day
     }
 }

--- a/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
@@ -1,0 +1,224 @@
+// TODO: is file header ok?
+/**
+ *
+ * Copyright (c) 2009-2015 Todo.txt contributors (http://todotxt.com)
+ * Copyright (c) 2013- Mark Janssen
+ *
+ * LICENSE:
+ *
+ * Simpletas is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Simpletask is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Sinpletask.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2015 Todo.txt contributors (http://todotxt.com)
+ * @copyright 2013- Mark Janssen
+ */
+
+package nl.mpcjanssen.simpletask;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.preference.MultiSelectListPreference;
+import android.provider.CalendarContract.Calendars;
+import android.provider.CalendarContract.Events;
+import android.provider.CalendarContract.Reminders;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+
+import hirondelle.date4j.DateTime;
+import nl.mpcjanssen.simpletask.task.Task;
+import nl.mpcjanssen.simpletask.task.TaskCache;
+
+public class CalendarSync {
+    private static final String TAG = CalendarSync.class.getSimpleName();
+    private static final String PACKAGE = TodoApplication.getAppContext().getPackageName();
+    private static final boolean API16 = android.os.Build.VERSION.SDK_INT >= 16;
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    private static final String PREFIX_DUE = "Task due: ";
+    private static final String PREFIX_THRESHOLD = "Task threshold: ";
+    private static final String EVT_DESCRIPTION = "Generated automatically by Simpletask";
+
+    private ContentResolver m_cr;
+    private List<Long> m_calendars;
+    private Set<Long> m_evtset;
+    private int m_margin_minutes = 1440;
+
+    private boolean calendarValid(String id, String name) {
+        Uri uri = Calendars.CONTENT_URI.buildUpon().appendPath(id).build();
+        final String[] projection = {Calendars._ID, Calendars.NAME, Calendars.CALENDAR_DISPLAY_NAME};
+        final String selection = Calendars.NAME+" = ?";
+        Cursor cursor = m_cr.query(uri, projection, selection, new String[]{name}, null);
+        boolean ret = cursor.getCount() == 1;
+        cursor.close();
+        return ret;
+    }
+
+    private void loadEvtSet(long calID) {
+        m_evtset.clear();
+
+        final String[] projection = {Events._ID, Events.CALENDAR_ID, Events.CUSTOM_APP_PACKAGE};
+        final String selection = Events.CALENDAR_ID+" = ? AND "+Events.CUSTOM_APP_PACKAGE+" = ?";
+        Cursor cursor = m_cr.query(Events.CONTENT_URI, projection, selection,
+                new String[]{Long.toString(calID), PACKAGE}, null);
+
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                m_evtset.add(cursor.getLong(0));
+            }
+            cursor.close();
+        }
+    }
+
+    private long findEvt(long calID, DateTime date, String title) {
+        final String[] projection = {Events._ID, Events.CALENDAR_ID, Events.CUSTOM_APP_PACKAGE,
+                Events.DTSTART, Events.TITLE};
+        final String selection = Events.CALENDAR_ID+" = ? AND "+Events.CUSTOM_APP_PACKAGE+" = ? AND "
+                +Events.DTSTART+" = ? AND "+Events.TITLE+" = ?";
+        Cursor cursor = m_cr.query(Events.CONTENT_URI, projection, selection,
+                new String[]{Long.toString(calID), PACKAGE, String.valueOf(date.getMilliseconds(UTC)), title}, null);
+
+        if (cursor == null) return -1;
+        if (cursor.getCount() != 1) return -1;
+        cursor.moveToFirst();
+        long ret = cursor.getLong(0);
+        cursor.close();
+        return ret;
+    }
+
+    private void insertEvt(long calID, DateTime date, String title) {
+        ContentValues values = new ContentValues();
+        long millis = date.getMilliseconds(UTC);
+
+        // Event:
+        values.put(Events.CALENDAR_ID, calID);
+        values.put(Events.TITLE, title);
+        values.put(Events.DTSTART, millis);
+        values.put(Events.DTEND, millis);
+        values.put(Events.ALL_DAY, true);
+        values.put(Events.DESCRIPTION, EVT_DESCRIPTION);
+        values.put(Events.EVENT_TIMEZONE, TimeZone.getDefault().getID());
+        values.put(Events.CUSTOM_APP_PACKAGE, PACKAGE);
+        // TODO: CUSTOM_APP_URI ?
+        Uri uri = m_cr.insert(Events.CONTENT_URI, values);
+
+        // Reminder:
+        long evtID = Long.parseLong(uri.getLastPathSegment());
+        values.clear();
+        values.put(Reminders.EVENT_ID, evtID);
+        values.put(Reminders.MINUTES, m_margin_minutes);
+        values.put(Reminders.METHOD, Reminders.METHOD_DEFAULT);
+        m_cr.insert(Reminders.CONTENT_URI, values);
+    }
+
+    private void syncCal(long calID, final List<Task> tasks) {
+        for (Task task: tasks) {
+            if (task.isCompleted()) continue;
+
+            // Check due date:
+            DateTime dt = task.getDueDate();
+            if (dt != null) {
+                String title = PREFIX_DUE+task.getText();
+                long id = findEvt(calID, dt, title);
+                if (id >= 0) {
+                    m_evtset.remove(id);  // Don't delete this event
+                } else {
+                    insertEvt(calID, dt, title);
+                }
+            }
+
+            // Check threshold date:
+            dt = task.getThresholdDate();
+            if (dt != null) {
+                String title = PREFIX_THRESHOLD+task.getText();
+                long id = findEvt(calID, dt, title);
+                if (id >= 0) {
+                    m_evtset.remove(id);  // Don't delete this event
+                } else {
+                    insertEvt(calID, dt, title);
+                }
+            }
+        }
+    }
+
+    private void purgeEvts() {
+        final String selection = Events._ID+" = ?";
+        for (Long id: m_evtset) {
+            m_cr.delete(Events.CONTENT_URI, selection, new String[]{id.toString()});
+        }
+    }
+
+
+    public CalendarSync(Set<String> calendars) {
+        m_cr = TodoApplication.getAppContext().getContentResolver();
+        m_calendars = new ArrayList<>();
+        m_evtset = new HashSet<>();
+        setSyncCalendars(calendars);
+    }
+
+    public void sync(TaskCache taskCache, int marginDays) {
+        final List<Task> tasks = taskCache.getTasks();
+        m_margin_minutes = marginDays * 1440;
+
+        for (Long calID: m_calendars) {
+            loadEvtSet(calID);
+            syncCal(calID, tasks);
+            purgeEvts();
+        }
+    }
+
+    public void fillPrefCalendarList(MultiSelectListPreference pref) {
+        List<String> entryValues = new ArrayList<>();
+        List<String> entries = new ArrayList<>();
+
+        final String[] projection = {Calendars._ID, Calendars.NAME, Calendars.CALENDAR_DISPLAY_NAME};
+        Cursor cursor = m_cr.query(Calendars.CONTENT_URI, projection, null, null, null);
+
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                // In an attempt to distinguish a calendar uniquely, both its ID and name is used:
+                String value = cursor.getString(0) + ":" + cursor.getString(1);
+                entryValues.add(value);
+                entries.add(cursor.getString(2));
+            }
+        }
+
+        pref.setEntryValues(entryValues.toArray(new CharSequence[entryValues.size()]));
+        pref.setEntries(entries.toArray(new CharSequence[entries.size()]));
+    }
+
+    public void setSyncCalendars(Set<String> calendars) {
+        m_calendars.clear();
+
+        // Custom events are supported only since JellyBean:
+        if (!API16) return;
+
+        for (String calendar: calendars) {
+            String[] split = calendar.split(":", 2);
+            if (calendarValid(split[0], split[1])) {
+                try {
+                    m_calendars.add(Long.parseLong(split[0]));
+                } catch (NumberFormatException e) {
+                    // Calendar ID not added
+                }
+            } else {
+                Log.w(TAG, "Calendar not valid, id: "+split[0]);
+            }
+        }
+    }
+}

--- a/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
@@ -1,8 +1,6 @@
-// TODO: is file header ok?
 /**
  *
- * Copyright (c) 2009-2015 Todo.txt contributors (http://todotxt.com)
- * Copyright (c) 2013- Mark Janssen
+ * Copyright (c) 2015 Vojtech Kral
  *
  * LICENSE:
  *
@@ -19,8 +17,7 @@
  *
  * @author Todo.txt contributors <todotxt@yahoogroups.com>
  * @license http://www.gnu.org/licenses/gpl.html
- * @copyright 2009-2015 Todo.txt contributors (http://todotxt.com)
- * @copyright 2013- Mark Janssen
+ * @copyright 2015 Vojtech Kral
  */
 
 package nl.mpcjanssen.simpletask;

--- a/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
@@ -105,11 +105,9 @@ public class Preferences extends ThemedActivity {
             aboutCategory.removePreference(toHide);
 
             if (!TodoApplication.API16) {
-                Preference calSyncPref = findPreference(getString(R.string.calendar_sync));
-                Preference calSyncDaysPref = findPreference(getString(R.string.calendar_reminder_days));
+                Preference calSyncPref = findPreference(getString(R.string.calendar_sync_screen));
                 PreferenceCategory behaviorCategory = (PreferenceCategory) findPreference(getString(R.string.behavior_cat_key));
                 behaviorCategory.removePreference(calSyncPref);
-                behaviorCategory.removePreference(calSyncDaysPref);
             }
         }
 

--- a/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
@@ -2,6 +2,7 @@
  * This file is part of Todo.txt Touch, an Android app for managing your todo.txt file (http://todotxt.com).
  *
  * Copyright (c) 2009-2012 Todo.txt contributors (http://todotxt.com)
+ * Copyright (c) 2015 Vojtech Kral
  *
  * LICENSE:
  *
@@ -19,6 +20,7 @@
  * @author Todo.txt contributors <todotxt@yahoogroups.com>
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2012 Todo.txt contributors (http://todotxt.com)
+ * @copyright 2015 Vojtech Kral
  */
 package nl.mpcjanssen.simpletask;
 

--- a/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
@@ -29,6 +29,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
@@ -102,6 +103,9 @@ public class Preferences extends ThemedActivity {
                 toHide = findPreference("donated");
             }
             aboutCategory.removePreference(toHide);
+
+            MultiSelectListPreference calendarList = (MultiSelectListPreference) findPreference(getString(R.string.calendar_sync));
+            m_app.getCalendarSync().fillPrefCalendarList(calendarList);
         }
 
         private void sendLog() {

--- a/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/Preferences.java
@@ -104,8 +104,13 @@ public class Preferences extends ThemedActivity {
             }
             aboutCategory.removePreference(toHide);
 
-            MultiSelectListPreference calendarList = (MultiSelectListPreference) findPreference(getString(R.string.calendar_sync));
-            m_app.getCalendarSync().fillPrefCalendarList(calendarList);
+            if (!TodoApplication.API16) {
+                Preference calSyncPref = findPreference(getString(R.string.calendar_sync));
+                Preference calSyncDaysPref = findPreference(getString(R.string.calendar_reminder_days));
+                PreferenceCategory behaviorCategory = (PreferenceCategory) findPreference(getString(R.string.behavior_cat_key));
+                behaviorCategory.removePreference(calSyncPref);
+                behaviorCategory.removePreference(calSyncDaysPref);
+            }
         }
 
         private void sendLog() {

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.java
@@ -4,6 +4,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2012 Todo.txt contributors (http://todotxt.com)
  * @copyright 2013- Mark Janssen
+ * @copyright 2015 Vojtech Kral
  */
 
 package nl.mpcjanssen.simpletask;
@@ -95,6 +96,9 @@ public class Simpletask extends ThemedListActivity implements
     final static String TAG = Simpletask.class.getSimpleName();
 
     private final static int REQUEST_PREFERENCES = 2;
+
+    public final static Uri URI_BASE = Uri.fromParts("simpletask", "", null);
+    public final static Uri URI_SEARCH = Uri.withAppendedPath(URI_BASE, "search");
 
     Menu options_menu;
     TodoApplication m_app;
@@ -804,6 +808,10 @@ public class Simpletask extends ThemedListActivity implements
             currentIntent.putExtra(SearchManager.QUERY, intent.getStringExtra(SearchManager.QUERY));
             setIntent(currentIntent);
             options_menu.findItem(R.id.search).collapseActionView();
+        } else if (CalendarContract.ACTION_HANDLE_CUSTOM_EVENT.equals(intent.getAction())) {
+            Uri uri = Uri.parse(intent.getStringExtra(CalendarContract.EXTRA_CUSTOM_APP_URI));
+            String search = uri.getLastPathSegment();
+            // TODO: activate search
         } else if (intent.getExtras() != null) {
             // Only change intent if it actually contains a filter
             setIntent(intent);

--- a/src/main/java/nl/mpcjanssen/simpletask/TodoApplication.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/TodoApplication.java
@@ -2,6 +2,7 @@
  *
  * Copyright (c) 2009-2012 Todo.txt contributors (http://todotxt.com)
  * Copyright (c) 2013- Mark Janssen
+ * Copyright (c) 2015 Vojtech Kral
  *
  * LICENSE:
  *
@@ -20,6 +21,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2012 Todo.txt contributors (http://todotxt.com)
  * @copyright 2013- Mark Janssen
+ * @copyright 2015 Vojtech Kral
  */
 package nl.mpcjanssen.simpletask;
 

--- a/src/main/java/nl/mpcjanssen/simpletask/TodoApplication.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/TodoApplication.java
@@ -82,7 +82,7 @@ public class TodoApplication extends Application implements SharedPreferences.On
         super.onCreate();
         TodoApplication.m_appContext = getApplicationContext();
         TodoApplication.m_prefs = PreferenceManager.getDefaultSharedPreferences(getAppContext());
-        m_calSync = new CalendarSync(this, isCalendarSync());
+        m_calSync = new CalendarSync(this, isSyncDues(), isSyncThresholds());
         localBroadcastManager = LocalBroadcastManager.getInstance(this);
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(Constants.BROADCAST_UPDATE_UI);
@@ -188,8 +188,12 @@ public class TodoApplication extends Application implements SharedPreferences.On
         return m_prefs.getBoolean(getString(R.string.show_txt_only), false);
     }
 
-    public boolean isCalendarSync() {
-        return API16 && m_prefs.getBoolean(getString(R.string.calendar_sync), false);
+    public boolean isSyncDues() {
+        return API16 && m_prefs.getBoolean(getString(R.string.calendar_sync_dues), false);
+    }
+
+    public boolean isSyncThresholds() {
+        return API16 && m_prefs.getBoolean(getString(R.string.calendar_sync_thresholds), false);
     }
 
     public int getRemindersMarginDays() {
@@ -388,12 +392,10 @@ public class TodoApplication extends Application implements SharedPreferences.On
             if (mFileStore!=null) {
                 mFileStore.setEol(getEol());
             }
-        } else if (s.equals(getString(R.string.calendar_sync))) {
-            boolean enabled = isCalendarSync();
-            m_calSync.setEnabled(enabled);
-            if (enabled) {
-                m_calSync.syncLater();
-            }
+        } else if (s.equals(getString(R.string.calendar_sync_dues))) {
+            m_calSync.setSyncDues(isSyncDues());
+        } else if (s.equals(getString(R.string.calendar_sync_thresholds))) {
+            m_calSync.setSyncThresholds(isSyncThresholds());
         } else if (s.equals(getString(R.string.calendar_reminder_days))) {
             m_calSync.syncLater();
         }

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -138,6 +138,14 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="show_txt_only_pref_title">Zeige nur .txt-Dateien</string>
     <string name="show_txt_only_summary">Zeige nur .txt-Dateien im Dateiauswahldialog.</string>
 
+    <!--TODO: translate-->
+    <string name="calendar_sync_screen_title">Calendar reminders</string>
+    <string name="calendar_sync_screen_summary">Automatically create calendar reminders for due and/or threshold dates.</string>
+    <string name="calendar_sync_dues_title">Due dates</string>
+    <string name="calendar_sync_thresholds_title">Threshold dates</string>
+    <string name="calendar_reminder_days_title">Reminders margin</string>
+    <string name="calendar_reminder_days_summary">How many days before the due/threshold date should the reminder be set.</string>
+
     <string name="drawer_fixed_landscape_title">Öffne im Querformat</string>
     <string name="drawer_fixed_landscape_summary">Immer im Querformat öffnen.</string>
 
@@ -325,6 +333,13 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="donate_summary">Spende wenn Dir Simpletask gefällt. Hinweis: Spenden ist freiwillig, Simpletask wird immer kostenlos verfügbar sein. </string>
     <string name="visit_donate_data">https://bitly.com/VYR7Fq</string>
     <string name="sort_reverse">Umgekehrte Sortierung</string>
+
+    <!-- Calendar sync -->
+    <!--TODO: translate-->
+    <string name="calendar_disp_name">Simpletask Reminders</string>
+    <string name="calendar_sync_prefix_due">Task due:</string>
+    <string name="calendar_sync_prefix_thre">Task threshold:</string>
+    <string name="calendar_sync_evt_desc">Generated automatically by Simpletask</string>
 </resources>
 
 

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -137,6 +137,14 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="show_txt_only_pref_title">Mostra solo i file .txt</string>
     <string name="show_txt_only_summary">Mostra solo i file .txt nel dialogo di selezione file.</string>
 
+    <!--TODO: translate-->
+    <string name="calendar_sync_screen_title">Calendar reminders</string>
+    <string name="calendar_sync_screen_summary">Automatically create calendar reminders for due and/or threshold dates.</string>
+    <string name="calendar_sync_dues_title">Due dates</string>
+    <string name="calendar_sync_thresholds_title">Threshold dates</string>
+    <string name="calendar_reminder_days_title">Reminders margin</string>
+    <string name="calendar_reminder_days_summary">How many days before the due/threshold date should the reminder be set.</string>
+
     <string name="drawer_fixed_landscape_title">Mostra cass. in orizz.</string>
     <string name="drawer_fixed_landscape_summary">Mostra i cassetti aperti quando in modalità orizzontale.</string>
 
@@ -324,4 +332,11 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="donate_summary">Dona se apprezzi Simpletask. NOTA: La donazione è volontaria, Simpletask sarà sempre libero.  </string>
     <string name="visit_donate_data">https://bitly.com/VYR7Fq</string>
     <string name="sort_reverse">Inverti ordine</string>
+
+    <!-- Calendar sync -->
+    <!--TODO: translate-->
+    <string name="calendar_disp_name">Simpletask Reminders</string>
+    <string name="calendar_sync_prefix_due">Task due:</string>
+    <string name="calendar_sync_prefix_thre">Task threshold:</string>
+    <string name="calendar_sync_evt_desc">Generated automatically by Simpletask</string>
 </resources>

--- a/src/main/res/values/donottranslate.xml
+++ b/src/main/res/values/donottranslate.xml
@@ -4,6 +4,7 @@
 This file is part of Todo.txt Touch, an Android app for managing your todo.txt file (http://todotxt.com).
 
 Copyright (c) 2009-2012 Todo.txt contributors (http://todotxt.com)
+Copyright (c) 2015 Vojtech Kral
 
 LICENSE:
 
@@ -21,6 +22,7 @@ You should have received a copy of the GNU General Public License along with Tod
 @author Todo.txt contributors <todotxt@yahoogroups.com>
 @license http://www.gnu.org/licenses/gpl.html
 @copyright 2009-2012 Todo.txt contributors (http://todotxt.com)
+@copyright 2015 Vojtech Kral
 -->
 <!--suppress ALL -->
 <resources>

--- a/src/main/res/values/donottranslate.xml
+++ b/src/main/res/values/donottranslate.xml
@@ -117,6 +117,8 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="show_hidden">show_hidden</string>
     <string name="show_empty_lists">show_empty_lists</string>
     <string name="show_txt_only">show_txt_only</string>
+    <string name="calendar_sync">calendar_sync</string>
+    <string name="calendar_reminder_days">calendar_reminder_days</string>
     <string name="ui_complete_checkbox">ui_complete_checkbox</string>
     <string name="ui_show_calendarview">ui_show_calendarview</string>
     <string name="ui_sort_case_sensitive">ui_sort_case_sensitive</string>

--- a/src/main/res/values/donottranslate.xml
+++ b/src/main/res/values/donottranslate.xml
@@ -99,6 +99,7 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="widget_theme_pref_key">widget_theme</string>
     <string name="widget_extended_pref_key">widget_extended</string>
     <string name="dropbox_cat_key">dropbox_category</string>
+    <string name="behavior_cat_key">behavior_category</string>
     <string name="clone_tags_key">clone_tags</string>
     <string name="word_wrap_key">word_wrap</string>
     <string name="color_due_date_key">color_due_date</string>

--- a/src/main/res/values/donottranslate.xml
+++ b/src/main/res/values/donottranslate.xml
@@ -118,7 +118,9 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="show_hidden">show_hidden</string>
     <string name="show_empty_lists">show_empty_lists</string>
     <string name="show_txt_only">show_txt_only</string>
-    <string name="calendar_sync">calendar_sync</string>
+    <string name="calendar_sync_screen">calendar_sync_screen</string>
+    <string name="calendar_sync_dues">calendar_sync_dues</string>
+    <string name="calendar_sync_thresholds">calendar_sync_thresholds</string>
     <string name="calendar_reminder_days">calendar_reminder_days</string>
     <string name="ui_complete_checkbox">ui_complete_checkbox</string>
     <string name="ui_show_calendarview">ui_show_calendarview</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 This file is part of Todo.txt Touch, an Android app for managing your todo.txt file (http://todotxt.com).
 
 Copyright (c) 2009-2012 Todo.txt contributors (http://todotxt.com)
+Copyright (c) 2015 Vojtech Kral
 
 LICENSE:
 
@@ -21,6 +22,7 @@ You should have received a copy of the GNU General Public License along with Tod
 @license http://www.gnu.org/licenses/gpl.html
 @copyright 2009-2012 Todo.txt contributors (http://todotxt.com)
 @copyright 2013 Mark Janssen
+@copyright 2015 Vojtech Kral
 -->
 <!--suppress ALL -->
 <resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -138,6 +138,11 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="show_txt_only_pref_title">Show txt files only</string>
     <string name="show_txt_only_summary">Only show .txt files in the file selection dialog.</string>
 
+    <string name="calendar_sync_pref_title">Calendar reminders</string>
+    <string name="calendar_sync_summary">Select calendars in which reminders will automatically be created for due and threshold dates.</string>
+    <string name="calendar_reminder_days_title">Calendar reminders margin</string>
+    <string name="calendar_reminder_days_summary">Number of days prior to the due or threshold date.</string>
+
     <string name="drawer_fixed_landscape_title">Open landscape drawers</string>
     <string name="drawer_fixed_landscape_summary">Always open the drawers in landscape mode.</string>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -138,10 +138,12 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="show_txt_only_pref_title">Show txt files only</string>
     <string name="show_txt_only_summary">Only show .txt files in the file selection dialog.</string>
 
-    <string name="calendar_sync_pref_title">Calendar reminders</string>
-    <string name="calendar_sync_summary">Automatically create calendar reminders for due and threshold dates.</string>
-    <string name="calendar_reminder_days_title">Calendar reminders margin</string>
-    <string name="calendar_reminder_days_summary">Number of days prior to the due or threshold date.</string>
+    <string name="calendar_sync_screen_title">Calendar reminders</string>
+    <string name="calendar_sync_screen_summary">Automatically create calendar reminders for due and/or threshold dates.</string>
+    <string name="calendar_sync_dues_title">Due dates</string>
+    <string name="calendar_sync_thresholds_title">Threshold dates</string>
+    <string name="calendar_reminder_days_title">Reminders margin</string>
+    <string name="calendar_reminder_days_summary">How many days before the due/threshold date should the reminder be set.</string>
 
     <string name="drawer_fixed_landscape_title">Open landscape drawers</string>
     <string name="drawer_fixed_landscape_summary">Always open the drawers in landscape mode.</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -139,7 +139,7 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="show_txt_only_summary">Only show .txt files in the file selection dialog.</string>
 
     <string name="calendar_sync_pref_title">Calendar reminders</string>
-    <string name="calendar_sync_summary">Select calendars in which reminders will automatically be created for due and threshold dates.</string>
+    <string name="calendar_sync_summary">Automatically create calendar reminders for due and threshold dates.</string>
     <string name="calendar_reminder_days_title">Calendar reminders margin</string>
     <string name="calendar_reminder_days_summary">Number of days prior to the due or threshold date.</string>
 
@@ -332,4 +332,10 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="donate_summary">Donate if you like simpletask. NOTE: Donation is voluntary, simpletask will always be free.  </string>
     <string name="visit_donate_data">https://bitly.com/VYR7Fq</string>
     <string name="sort_reverse">Reverse sort</string>
+
+    <!-- Calendar sync -->
+    <string name="calendar_disp_name">Simpletask Reminders</string>
+    <string name="calendar_sync_prefix_due">Task due:</string>
+    <string name="calendar_sync_prefix_thre">Task threshold:</string>
+    <string name="calendar_sync_evt_desc">Generated automatically by Simpletask</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -170,21 +170,26 @@
             android:key="@string/show_txt_only"
 	        android:summary="@string/show_txt_only_summary"
             android:title="@string/show_txt_only_pref_title" />
-
-        <CheckBoxPreference
-            android:key="@string/calendar_sync"
-            android:summary="@string/calendar_sync_summary"
-            android:title="@string/calendar_sync_pref_title" />
-        <com.robobunny.SeekBarPreference xmlns:robobunny="http://robobunny.com"
-            android:key="@string/calendar_reminder_days"
-            android:title="@string/calendar_reminder_days_title"
-            android:summary="@string/calendar_reminder_days_summary"
-            android:defaultValue="1"
-            android:max="7"
-            robobunny:min="1"
-            robobunny:unitsLeft=""
-            robobunny:unitsRight="" />
-
+        <PreferenceScreen
+            android:key="@string/calendar_sync_screen"
+            android:summary="@string/calendar_sync_screen_summary"
+            android:title="@string/calendar_sync_screen_title">
+            <CheckBoxPreference
+                android:key="@string/calendar_sync_dues"
+                android:title="@string/calendar_sync_dues_title" />
+            <CheckBoxPreference
+                android:key="@string/calendar_sync_thresholds"
+                android:title="@string/calendar_sync_thresholds_title" />
+            <com.robobunny.SeekBarPreference xmlns:robobunny="http://robobunny.com"
+                android:key="@string/calendar_reminder_days"
+                android:title="@string/calendar_reminder_days_title"
+                android:summary="@string/calendar_reminder_days_summary"
+                android:defaultValue="1"
+                android:max="7"
+                robobunny:min="1"
+                robobunny:unitsLeft=""
+                robobunny:unitsRight="" />
+        </PreferenceScreen>
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/DROPBOX_settings_header"

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -117,7 +117,10 @@
             android:summary="@string/sort_case_sensitive_summary"/>
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/todotxt_behavior_settings_header">
+    <PreferenceCategory
+        android:title="@string/todotxt_behavior_settings_header"
+        android:key="@string/behavior_cat_key">
+
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/prepend_date_pref_key"
@@ -168,7 +171,7 @@
 	        android:summary="@string/show_txt_only_summary"
             android:title="@string/show_txt_only_pref_title" />
 
-        <MultiSelectListPreference
+        <CheckBoxPreference
             android:key="@string/calendar_sync"
             android:summary="@string/calendar_sync_summary"
             android:title="@string/calendar_sync_pref_title" />

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -165,8 +165,23 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/show_txt_only"
-	    android:summary="@string/show_txt_only_summary"
-            android:title="@string/show_txt_only_pref_title" /> 
+	        android:summary="@string/show_txt_only_summary"
+            android:title="@string/show_txt_only_pref_title" />
+
+        <MultiSelectListPreference
+            android:key="@string/calendar_sync"
+            android:summary="@string/calendar_sync_summary"
+            android:title="@string/calendar_sync_pref_title" />
+        <com.robobunny.SeekBarPreference xmlns:robobunny="http://robobunny.com"
+            android:key="@string/calendar_reminder_days"
+            android:title="@string/calendar_reminder_days_title"
+            android:summary="@string/calendar_reminder_days_summary"
+            android:defaultValue="1"
+            android:max="7"
+            robobunny:min="1"
+            robobunny:unitsLeft=""
+            robobunny:unitsRight="" />
+
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/DROPBOX_settings_header"

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -170,7 +170,7 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/show_txt_only"
-	        android:summary="@string/show_txt_only_summary"
+            android:summary="@string/show_txt_only_summary"
             android:title="@string/show_txt_only_pref_title" />
         <PreferenceScreen
             android:key="@string/calendar_sync_screen"

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -5,6 +5,7 @@
 	file (http://todotxt.com).
 
 	Copyright (c) 2009-2012 Todo.txt contributors (http://todotxt.com)
+	Copyright (c) 2015 Vojtech Kral
 
 	LICENSE:
 
@@ -27,6 +28,7 @@
 	@author Todo.txt contributors <todotxt@yahoogroups.com>
 	@license http://www.gnu.org/licenses/gpl.html
 	@copyright 2009-2012 Todo.txt contributors (http://todotxt.com)
+	@copyright 2015 Vojtech Kral
 --><!-- suppress ALL -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 


### PR DESCRIPTION
Basic (very imperfect) implementation of calendar due&threshold date sync.

I do not actually expect this PR to be merged, I created it because it's easier to see & talk about the code like this.

This is basically just a proof-of-concept imeplementation. There are a few issues right now:
+ requires API level 16 because of `Events.CUSTOM_APP_PACKAGE` (without that I don't know how to mark events belonging to Simpletask)
+ sync routine is rather slow, as it involves lookups of existing events, effectively making it O(n^2)
+ if a calendar is removed from the sync settings, its Simpletask events are not removed
+ if the reminders margin days number is changed, existing reminders are not altered

...and there's probably more. But the very basic functionality has been ok, at least on my device.

Thoughts welcome.
