### PR TITLE
Spanish translation

### DIFF
--- a/src/main/assets/MYN.es.md
+++ b/src/main/assets/MYN.es.md
@@ -1,0 +1,36 @@
+Gestione Su Ahora (Manage Your Now - MYN)
+=========================================
+
+Creando los contextos para MYN
+------------------------------
+
+MYN Define 3 zonas de urgencia, que nosotros hacemos corresponder a listas en Simpletask de tal manera que se ordenen correctamente.
+
+-   Crítico Ahora -\> `@CriticalNow`
+-   Oportunidad Ahora -\> `@OpportunityNow`
+-   Más allá del Horizonte -\> `@OverTheHorizon`
+
+Además MYN define una zona de Resultado Significativo (SOC - Significant Outcome) que necesita estar en lo alto de su lista. Para conseguirlo, lo hacemos corresponder a:
+
+-   Resultado Significativo -\> `@!SOC`
+
+Una desventaja del formato `todo.txt` en combinación con Simpletask es que si el archivo no contiene ningún elemento con una lista específica, la lista no aparecerá en Simpletask. Para evitar esto, Simpletask tiene un concepto llamado tareas escondidas. Estas tareas están marcadas con \`h:1' y de forma predeterminada no aparecerán en el listado de tareas. Sin embargo, cualquier etiqueta o lista definida para esta tarea sí estará disponible.
+
+Así que, para hacer las listas MYN persistentes, añada una tarea escondida para cada una p. ej.:
+
+    @CriticalNow h:1
+
+Configurando la ordenación para MYN
+-----------------------------------
+
+![](./images/MYN_sort.png)
+
+Para diferir tareas en Simpletask a Diferir-Hacer o Diferir-Revisar  utilizamos la función fecha umbral. Asegurese de que en ajustes el `Diferir por fecha umbral` está marcado. Entonces puede usar la fecha umbral `t:yyyy-mm-dd` como fecha de comienzo en MYN/1MTD
+
+Puede o bien esconder tareas futuras (desde la solapa `Otro` de filtros) o bien ordenarlas hacia el final (de modo que todavía son visibles pero sin interferir). Para conseguirlo  utilizamos la ordenación `fecha umbral en el futuro`. La otra configuración necesaria es ordenar su lista por fecha umbral invertida de modo que las tareas más antiguas serán ordenadas más atrás en la lista. Además de que realmente no importará cómo ordene después de eso, vea la imagen para un ejemplo.
+
+Utilizando la lista
+-------------------
+
+Cuando este revisando los elementos en su lista y quiera diferir una o más tareas, las puede seleccionar y utilizar el elemento de menú `diferir` en el menú. Hay algunas opciones ya rellenas que utilizaría a menudo en MYN/1MTD o puede diferirla a una fecha específica. Después de diferir la tarea se moverá al final del listado si ha sido diferida al futuro y fuera de su vista.
+

--- a/src/main/assets/addtask.es.md
+++ b/src/main/assets/addtask.es.md
@@ -1,0 +1,31 @@
+Esta pantalla le permite añadir tareas nuevas o actualizar las que ya existen. Cada línea en la caja de texto se convertirá en una tarea. hay dos casillas opcionales:
+
+* Salto de línea automático: Si las líneas largas deberían ser escritas en varias líneas o escapar por la derecha.
+* Rellenar la próxima: Cuándo esta marcada, pulsando siguiente (o entrar) en el teclado  rellenará la línea próxima con las 
+ etiquetas y listas de la línea anterior. Esto hace muy fácil añadir rápidamente múltiples tareas con las mismas listas y etiquetas.
+
+
+Añadir Tarea
+------------
+
+
+
+Actualizar Tarea
+----------------
+
+
+Extensiones
+-----------
+
+Simpletask soporta las siguientes extensiones de todo.txt:
+
+-   Fecha de vemcimiento: `due:YYYY-MM-DD` (año-mes-día)
+-   Fecha umbral/de inicio: `t:YYYY-MM-DD`
+-   Tareas recurrentes: `rec:[0-9]+[dwmy]` (días, semanas, meses, años) como se describe [aquí](https://github.com/bram85/todo.txt-tools/wiki/Recurrence) pero con alguna variación.
+    - De forma predeterminada Simpletask utilizará las fechas originales de la tarea para crear la tarea recurrente, no la fecha de conclusión como se describe en el enlace. Este comportamiento puede ser configurado de los Ajustes.
+
+Enlaces
+------
+
+- [Índice de ayuda](./index.es.md)
+

--- a/src/main/assets/defertasks.es.md
+++ b/src/main/assets/defertasks.es.md
@@ -1,0 +1,16 @@
+Diferir Tareas
+==============
+
+NOTA: En versiones recientes puedes diferir ambas, fecha de vencimiento y fecha de umbral y esta discusión está obsoleta.
+
+La funcionalidad de diferir en Simpletask es el diferir descrito en  [MYN](http://www.michaellinenberger.com/1MTDvsMYN.html) para diferir la ejecución/revisión.
+
+No pretende ser una fecha de vencimiento. Solo trata de retirar las tareas de prioridad baja fuera de la vista por ahora y hacerlas reaparecer en un tiempo prefijado en el futuro (1 semana, 2 semanas o 1 mes). Para conseguir esto filtro las tareas con fecha de umbral situada en futuro. Cuándo la fecha de inicio diferido llega, las tareas  automáticamente vuelven a vista activa (con la ordenación correcta)
+
+También podría utilizar esto con una lista de tareas más al estilo GTD (Get Things Done). Es una manera rápida de conseguir que una acción futura no se interponga en el camino, sin moverla a Algún día/Quizás. Si se salta la revisión de tareas futuras en la revisión diaria o semanal no tendrá que ver tareas que sabe que no tendrá que hacer pronto.
+
+Entonces, por qué no utilizar la fecha de vencimiento para esto? Hay varias razones:
+
+> -   Las fechas de vencimiento son generalmente en el futuro por lo que no es muy utilizable para el concepto MYN/1MTD de fecha en el futuro -\> fuera de la vista.
+> -   Fechas de vencimiento diferibles llevan a tareas no hechas y a menudo pospuestas. Una tarea sólo tendría que tener una fecha de vencimiento si necesita hacerse indefectiblemente antes de dicho día o algo malo pasaría. No debería ser un indicador de "deseo que sea hecho en esa fecha". Ambos GTD y MYN estan de acuerdo eso no funciona.
+

--- a/src/main/assets/design.es.md
+++ b/src/main/assets/design.es.md
@@ -1,0 +1,30 @@
+Consideraciones de diseño
+=========================
+
+Consideraciones de diseño general
+---------------------------------
+
+-   Sencillo
+    -   Interfaz de usuario sigue las directrices Android
+-   Suficiente funcionalidad para hacer GTD
+    -   Listas separadas
+    -   Habilidad para etiquetar
+-   Formato de almacenamiento documentado
+    -   Formato todo.txt con manejo especial de (.....)
+-   Aplicable para escenarios de uso múltiple
+    -   Tendría que ser utilizable sin dropbox
+
+Formato de archivo
+------------------
+
+### Listas (Contextos en todo.txt)
+
+### Etiquetas (Proyectos en todo.txt)
+
+### Notas (Ningún equivalente en todo.txt)
+
+Otras consideraciones
+---------------------
+
+-   Simpletask está escrito de tal manera que la misma documentación se utiliza en Github y en la aplicación. Esto requiere algunas dependencias adicionales para la aplicación (un lector-analizador para Markdown y uno para HTML), pero permite que el mantener sincronizados todos los documentos sea mucho más fácil.
+

--- a/src/main/assets/gradle.es.md
+++ b/src/main/assets/gradle.es.md
@@ -1,0 +1,20 @@
+Utilizando el nuevo sistema de compilación Gradle
+=================================================
+
+El sistema de compilación ha sido cambiado de ant/Eclipse/Idea a gradle por dos razones principales:
+
+1.  Gradle hace muy fácil tener diferentes variantes de su aplicación con el mismo código (p. ej. una libre y una de donación)
+2.  Gradle es el nuevo sistema de compilación oficial de Android así que el cambio tenia que pasar en todo caso.
+
+Descripción del proceso de compilación
+--------------------------------------
+
+Use `gradle(w) tasks` para conseguir una lista completa, la tareas útiles ya definidas son:
+
+-   `assembleReleaseFree`: compilación de la apk libre para la Tienda de Google
+-   `assembleReleaseDonate`: compilación de la apk de donación
+-   `installDevDebug`: compilación de una versión del código fuente actual que pueden ser instalada en paralelo con la versión de la Tienda de Google.
+-   `connectedInstrumentTestUnitDebug`: Una variante especial para testeo unitario. No quiero utilizar la versión Dev para esto porque se desinstala después de la ejecución de prueba.
+-   `check`: Depende de `connectedInstrumentTestUnitDebug` de modo que ejecuta la batería de pruebas.
+-   `build`: Compila todas las variantes de la aplicación de golpe, también depende de `check` de modo que correrá la batería de pruebas
+

--- a/src/main/assets/index.es.md
+++ b/src/main/assets/index.es.md
@@ -1,0 +1,36 @@
+Simpletask
+==========
+(See in [English](./index.md). Ver en [Inglés](./index.md).
+
+[Simpletask](https://github.com/mpcjanssen/simpletask-android) está basado en el brillante [todo.txt](http://todotxt.com) (ParaHacer.txt) de [Gina Trapani](http://ginatrapani.org/). El objetivo de la aplicación es proporcionar una herramienta para utilizar GTD (Get Things Done, "Organízate con eficacia" sin proporcionar una cantidad agobiante de opciones. Pese a que Simpletask puede ser personalizado con una cantidad considerable de Ajustes, los predeterminados tendrían que ser adecuados y no requerir ningún cambio.
+
+[Simpletask](http://mpcjanssen.nl/doc/simpletask/) puede ser utilizado como un gestor muy sencillo de listas de tareas para hacer o como un gestor de acciones más complejas para GTD o [Gestione Su Ahora, Manage Your Now](./Myn.es.md).
+
+Extensiones
+-----------
+
+Simpletask soporta las siguientes extensiones de todo.txt:
+
+-   Fecha de vencimiento: `due:YYYY-MM-DD` (año-mes-día)
+-   Fecha umbral/de inicio: `t:YYYY-MM-DD`
+-   Tareas recurrentes: `rec:[0-9]+[dwmy]` (días, semanas, meses, años) como se describe [aquí](https://github.com/bram85/todo.txt-tools/wiki/Recurrence) pero con alguna variación.
+    - De forma predeterminada Simpletask utilizará las fechas originales de la tarea para crear la tarea recurrente, no la fecha de conclusión como se describe en el enlace. Este comportamiento puede ser configurado de los Ajustes.
+    - La descripción del formato unas lineas más arriba es una [expresión regular](http://es.wikipedia.org/wiki/Expresi%C3%B3n_regular), o sea, que en lenguaje humano la sintaxis es `rec:` seguido de 1 o más números (el `+`) seguido por una de las siguientes `d` día, `w` semana, `m` mes o `y` año. Por ejemplo `rec:12d` especifica una tarea recurrente cada 12 días.
+- Tareas escondidas: `h:1`, esto permite tareas ficticias asignadas a listas y etiquetas predefinidas de modo que las mismas esten disponibles incluso si la última tarea que las contenía se borra del archivo `todo.txt`. Estas tareas no serán mostradas de forma predeterminada. Temporalmente se pueden mostrar usando los Ajustes.
+
+Soporte
+-------
+
+[![Unase al chat en https://gitter.im/mpcjanssen/simpletask-android](./images/gitter.svg)](https://gitter.im/mpcjanssen/simpletask-android?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Si  quiere informar de un problema o pedir una característica nueva para [Simpletask](https://github.com/mpcjanssen/simpletask-android/) puede ir a [el tracker](https://github.com/mpcjanssen/simpletask-android/issues). Si encuentra Simpletask útil, puedes comprar la aplicación (vea Ajustes) o donarme vía [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mpc%2ejanssen%40gmail%2ecom&lc=NL&item_name=mpcjanssen%2enl&item_number=Simpletask&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted) unas cervezas.
+
+Vea el menú para encontrar más secciones de ayuda o haga clic abajo.
+
+- [Interfaz de usuario](./ui.es.md) Ayuda para la interfaz de usuario.
+- [Changelog](./changelog.md)
+- [Listas y Etiquetas](./listsandtags.es.md) Por Simpletask usa listas y etiquetas en lugar de Contextos y Proyectos de todo.txt?
+- [Definiendo intents](./intents.es.md) Intents que pueden ser utilizados para automatizar Simpletask
+- [Utilizando Simpletask para 1MTD/MYN - 1 Minute ToDo List/Manage Your Now](./Myn.es.md)
+- [Filtrando con Lua](./script.es.md)
+

--- a/src/main/assets/index.md
+++ b/src/main/assets/index.md
@@ -1,5 +1,6 @@
 Simpletask
 ==========
+(See in [Spanish](./index.es.md). Ver en [Español](./index.es.md).
 
 [Simpletask](https://github.com/mpcjanssen/simpletask-android) is based on the brilliant [todo.txt](http://todotxt.com) by [Gina Trapani](http://ginatrapani.org/). The goal of the application is to provide a tool to do GTD without providing an overwhelming amount of options. Even though Simpletask can be customised by a fairly large amount of settings, the defaults should be sane and require no change.
 

--- a/src/main/assets/intents.es.md
+++ b/src/main/assets/intents.es.md
@@ -1,0 +1,128 @@
+Intents
+=======
+
+Simpletask soporta un par de intents que pueden ser utilizados por otras aplicaciones (p. ej. tasker) para crear tareas o mostrar listas.
+
+Crear tarea entre bastidores
+----------------------------
+
+Para crear una tarea entre bastidores, tan sin mostrar simpletask,  puede utilizar el intent:
+
+-   Intent action: `nl.mpcjanssen.simpletask.BACKGROUND_TASK`
+-   Intent string extra: `task`
+
+El intent tendrá una cadena extra `task` qué contiene la tarea para ser añadida.
+
+Por ejemplo para crear una tarea desde tasker, use la acción siguiente:
+
+-   Action: `nl.mpcjanssen.simpletask.BACKGROUND_TASK`
+-   Cat: Default
+-   Mime Type: text/\*
+-   Extra: task: `<Task text with possible variables here> +tasker`
+-   Target: Activity
+
+Me gusta añadir la etiqueta `+tasker` para posder filtrar rápidamente la tareas creadas por tasker.
+
+Abrir con un filtro específico
+------------------------------
+
+Para abrir Simpletask con un filtro específico puede utilizar el intent:
+
+-   Intent action: `nl.mpcjanssen.simpletask.START_WITH_FILTER`
+-   Intent extras: Los extras siguientes pueden ser añadidos como parte del intent. Note que actualmente los nombres todavía reflejan los nombres originales de listas/etiquetas.
+
+<table>
+<colgroup>
+<col width="19%" />
+<col width="12%" />
+<col width="67%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th align="left">Nobre</th>
+<th align="left">Tipo</th>
+<th align="left">Descrición</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">CONTEXTS</td>
+<td align="left">String</td>
+<td align="left">lista de listas en filtro separadas por 'n' or ','</td>
+</tr>
+<tr class="even">
+<td align="left">PROJECTS</td>
+<td align="left">String</td>
+<td align="left">lista de etiquetas en filtro separadas por 'n' or ','</td>
+</tr>
+<tr class="odd">
+<td align="left">PRIORITIES</td>
+<td align="left">String</td>
+<td align="left">lista de prioridades en filtro separadas por 'n' or ','</td>
+</tr>
+<tr class="even">
+<td align="left">CONTEXTSnot</td>
+<td align="left">Boolean</td>
+<td align="left">true para invertir el filtro de listas</td>
+</tr>
+<tr class="odd">
+<td align="left">PROJECTSnot</td>
+<td align="left">Boolean</td>
+<td align="left">true para invertir el filtro de etiquetas</td>
+</tr>
+<tr class="even">
+<td align="left">PRIORITIESnot</td>
+<td align="left">Boolean</td>
+<td align="left">true para invertir el filtro de prioridades</td>
+</tr>
+<tr class="odd">
+<td align="left">HIDECOMPLETED</td>
+<td align="left">Boolean</td>
+<td align="left">true para ocultar las tareas completadas</td>
+</tr>
+<tr class="even">
+<td align="left">HIDEFUTURE</td>
+<td align="left">Boolean</td>
+<td align="left">true para ocultar las tareas con fecha umbral</td>
+</tr>
+<tr class="odd">
+<td align="left">SORTS</td>
+<td align="left">String</td>
+<td align="left">ordenación vigente (ver abajo)</td>
+</tr>
+</tbody>
+</table>
+
+### Extra ordenación
+
+SORTS contiene una lista separada por comas o '' de claves para ordenación y su dirección separadas por un `!`. Suministrar `<dirección>!<clave para ordenación>`.
+
+#### Dirección
+
+-   `+` : Ascendente
+-   `-` : Descendente
+
+#### Claves para ordenación
+
+Vea la lista en [arrays.xml](https://github.com/mpcjanssen/simpletask-android/blob/master/src/main/res/values/donottranslate.xml#L42-51)
+
+#### Ejemplo
+
+-   La ordenación `+!completed,+!alphabetical` ordena las tareas colocando las completadas detrás y después las ordena alfabéticamente.
+-   La ordenación `+!completed,-!alphabetical` ordena las tareas colocando las completadas detrás y después las ordena en orden alfabético inverso.
+
+### Ejemplo de Tasker
+
+-   Action: `nl.mpcjanssen.simpletask.START_WITH_FILTER`
+-   Cat: `Default`
+-   Mime Type:
+-   Extra: `CONTEXTS:Officina,Online`
+-   Extra: `SORTS:+!completed,+!alphabetical`
+-   Target: `Activity`
+
+Debido a limitaciones en Tasker sólo puede añadir 2 extras. Si precisa más puede utilizar el comando shell am. Por ejemplo:
+
+    am start -a nl.mpcjanssen.simpletask.START_WITH_FILTER -e SORTS +!completed,+!alphabetical -e PROJECTS proyecto1,proyecto2 -e CONTEXTS @compras,@ordenador --ez CONTEXTSnot true -c android.intent.category.DEFAULT -S
+
+La `-S` al final asegurará que la aplicación arranca de nuevo correctamente si ya estaba visible. Aun así con tasker la `-S` parece que no funciona. Así que pruebe si ella.
+

--- a/src/main/assets/listsandtags.es.md
+++ b/src/main/assets/listsandtags.es.md
@@ -1,0 +1,19 @@
+# Listas y Etiquetas
+
+Por qué usa Simpletask Listas y Etiquetas?
+
+## Contextos vs Listas
+
+En vez de los contextos y proyectos en todo.txt, Simpletask llama `@algo` una lista y `+algo` una etiqueta. Por qué se decidió esto, no va GTD totalmente sobre contextos?
+
+Bueno, realmente no. Incluso aunque esto no está tan claramente articulado en el libro original Organízate Con Eficacia (Getting Things Done - GTD) como podría haberlo estado, en GTD el principal elemento organizador es la lista. Algunas de estas listas contienen acciones futuras para un cierto contexto (p. ej. @ordenador) pero otras no (p. ej. Proyectos o En Espera).
+
+Por tanto, incluso aunque muchas listas en GTD contendrán acciones futuras para un cierto contexto, esto no implica que el contexto es el principal elemento organizador (p. ej. En Espera no es un contexto)
+
+## Proyectos vs Etiquetas
+
+Los proyectos están rebautizados a etiquetas porque etiquetas es un concepto más general. Una etiqueta puede ser cualquier cosa desde un proyecto al nombre de una persona. Esto permite utilizar tareas como:
+
+`@Llamar +DavidAllen con respecto a +GTD`
+
+En este caso ninguna de las etiquetas son proyectos.

--- a/src/main/assets/script.es.md
+++ b/src/main/assets/script.es.md
@@ -1,0 +1,57 @@
+Scripting
+=========
+
+Explicación
+===========
+
+Simpletask proporciona (experimentalmente) filtrado avanzado de tareas utilizando Lua. Para utilizar Lua  necesitará habilitarlo en los ajustes.
+
+Después de habilitar Lua, la actividad de filtrado mostrará una solapa adicional SCRIPT. Para cada tarea se ejecutará una pieza de Lua.  Dependiendo del valor booleano de la orden return, la tarea es visible (en caso de `true`) o filtrada y excluida (en caso de `false`). Para ayudar con escribir el script puede probar el script en una tarea de ejemplo y el resultado crudo y el resultado interpretado en forma de booleano se mostrará.
+
+Variables definidas
+-------------------
+ 
+Para hacer el filtrado más fácil, para cada tarea un par de variables globales están definidas. Puede utilizarlas en su código.
+
+* `completed`: Booleano indicando si la tarea está completada.
+* `completiondate`: La fecha de conclusión de la tarea en segundos o `nil` si no está establecida.
+* `createdate`: La fecha de creación de la tarea en segundos o `nil` si no está establecida.
+* `due`: La fecha de vencimiento en segundos o `nil` si no está establecida.
+* `lists`: Una matriz de cadenas alfanuméricas con las listas de la tarea.
+* `priority`: La prioridad de la tarea cuando cuerda.
+* `recurrence`: El patrón de recurrencia de la tarea como cadena alfanumérica o `nil` si no está establecida.
+* `tags`: Una matriz de cadenas alfanuméricas con las etiquetas de la tarea.
+* `task`: la tarea completa como cadena alfanumérica.
+* `threshold`: La fecha umbral en segundos o `nil` si no está establecida.
+
+Ejemplo
+-------
+
+El código siguiente mostrará solo las tareas pasadas de fecha considerando que las tareas sin una fecha prevista, nunca estarán pasadas de fecha.
+
+    if (due~=nil) {
+         return os.time() > due;
+    }
+    --- tareas sin la fecha prevista no es estaran pasadas de fecha.
+    return false;
+
+Una ejecución del filtro sobre todas las  tareas utiliza un contexto de evaluación único, de modo que cualquier otro estado global se retiene de tarea a tarea. Esto permite hacer algunas cosas "interesantes" como mostrar las cien primeras tareas:
+
+    if c == nil then
+        c = 0
+    end
+    c = c + 1; 
+    return c <= 100;
+
+Notas
+-----
+
+* El script se ejecuta para cada tarea al mostrarla, así que asegúrese de que sea rápido. Hacer demasiado trabajo en el script lentificará Simpletask.
+* Cualquier informe ANR para el cual el script este puesto en el filtro tendrá altas posibilidad de que se ignore.  _A un gran poder la acompaña una gran responsabilidad_.
+
+
+Qué sigue?
+----------
+
+Esta explicación tendría que ser suficiente para empezar a funcionar.
+

--- a/src/main/assets/ui.es.md
+++ b/src/main/assets/ui.es.md
@@ -1,0 +1,30 @@
+Interfaz de usuario
+===================
+
+Esta página explica la interfaz de usuario. De momento esto es un trabajo en marcha por lo que no cubre todos los elementos todavía.
+
+
+## Actividad de Filtrado
+
+### Invertir filtro
+
+La opción invertir es para utilizar el negativo de los elementos seleccionados. Para dar un ejemplo de por qué esto es útil.
+
+Imagine que tiene las siguientes listas definidas:
+
+- `@trabajo`
+- `@casa`
+- `Proyecto`
+- `AlgúnDía`
+
+Dos de estas listas contienen acciones próximas (`@trabajo` y `@casa`) las otras dos no. Ahora si quiere crear un filtro para mostrar únicamente las acciones próximas hay dos maneras para hacerlo. Una manera incorrecta y una manera correcta.
+
+### La manera 'incorrecta'
+
+Crear un filtro con las opciones `@trabajo` y `@casa` marcadas.  Inicialmente esto funcionará. Sin embargo, cuándo cree un elemento con la lista `@compras` qué también sea una acción próxima, tendrá que actualizar el filtro para acciones próximas. Así que es fácil que acciones próximas pasen inadvertidas.
+
+### La manera 'correcta'
+
+Crear un filtro con las opciones `Proyecto` y `AlgúnDía` marcadas y también marcar `Invertir filtro`.  Ahora todos los  elementos qué no estén en las listas `Proyecto` y `AlgúnDía` se mostrarán después de filtrar. Esto significa que si añade una tarea `@compras` ésta también será incluida en los resultados.
+
+Naturalmente, si añade un nuevo listado que no contiene acciones próximas (p. ej. `@ProyectoPrivado`) estas también se mostrarán y el filtro requerirá ser cambiado. La gran diferencia con la manera 'incorrecta' es que este camino podría mostrar demasiada información en lugar de demasiado poca, lo cual es preferible.

--- a/src/main/assets/versions.es.md
+++ b/src/main/assets/versions.es.md
@@ -1,0 +1,28 @@
+Versiones
+=========
+
+Simpletask existe en dos versiones diferentes en la Tienda de Google. Simpletask y Simpletask Cloudless. Abajo puede encontrar una visión general de las diferencias entre estas versiones y cuál sería adecuada para usted.
+
+Pretendo mantener ambas versiones. Simpletask porque tiene un colectivo de usuarios. Simpletask Cloudless porque es la que utilizo.
+
+Simpletask
+----------
+
+-   Versión con soporte para sincronización con Dropbox.
+-   Los archivos ParaHacer (Todo) están almacenados dentro del almacenamiento de la aplicación y son borrados al desinstalar
+-   Utilize ésta si ya tiene una cuenta Dropbox y quiere disponer de una instalación libre de complicaciones que funciona rápidamente.
+
+Simpletask Cloudless
+--------------------
+
+-   No tiene soporte de sincronización integrado. Depende de otros sistemas (como Dropsync o Foldersync) para sincronizar con un gran número de opciones en la nube.
+-   No requiere permiso de INTERNET así que es aceptable para leyes de exportación exigentes.
+-   Todo los archivos están almacenados en la tarjeta SD (de forma predeterminada en \`data/nl.mpcjanssen.simpletask\`) así que también puede ser utilizado en modo off-line.
+-   Vuelve a recargar la lista de tareas si un programa externo cambia el archivo ParaHacer (Todo).
+-   Utilize ésta si quiere sincronizar con otras opciones de la nube que no sean Dropbox o si quiere utilizarla en modo off-line.
+
+Versiones de donación
+---------------------
+
+Solía haber versiones de donación en la Tienda de Google también, pero puesto que son exactamente iguales a las versiones libres,  se estaban convirtiendo en un engorro el mantenerlas. Si quiere donar, puede encontrar un enlace de donación en los ajustes.
+

--- a/src/main/java/nl/mpcjanssen/simpletask/AddTask.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/AddTask.java
@@ -147,7 +147,7 @@ public class AddTask extends ThemedActivity {
 
     private void showHelp() {
         Intent i = new Intent(this, HelpScreen.class);
-        i.putExtra(Constants.EXTRA_HELP_PAGE,Constants.HELP_ADD_TASK);
+        i.putExtra(Constants.EXTRA_HELP_PAGE,getText(R.string.help_add_task));
         startActivity(i);
     }
 

--- a/src/main/java/nl/mpcjanssen/simpletask/HelpScreen.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/HelpScreen.java
@@ -58,7 +58,7 @@ public class HelpScreen extends Activity {
         super.onCreate(savedInstanceState);
         TodoApplication m_app = (TodoApplication) getApplication();
         setTheme(m_app.getActiveTheme());
-        String page = Constants.HELP_INDEX;
+        String page = getText(R.string.help_index).toString();
         Intent i = getIntent();
         if (i.hasExtra(Constants.EXTRA_HELP_PAGE)) {
             page = i.getStringExtra(Constants.EXTRA_HELP_PAGE);
@@ -136,7 +136,7 @@ public class HelpScreen extends Activity {
             Log.e(TAG,""+e);
         }
         history.push(name);
-        wv.loadDataWithBaseURL(BASE_URL, html,"text/html", "UTF-8","file:///android_asset/index.md");
+        wv.loadDataWithBaseURL(BASE_URL, html,"text/html", "UTF-8","file:///android_asset/index" + getText(R.string.help_translation) + ".md");
     }
 
 
@@ -145,22 +145,22 @@ public class HelpScreen extends Activity {
         switch (item.getItemId()) {
             // Respond to the action bar's Up/Home button
             case R.id.menu_simpletask:
-                showMarkdownAsset(wvHelp,this,"index.md");
+                showMarkdownAsset(wvHelp,this,"index" + getText(R.string.help_translation) + ".md");
                 return true;
             case R.id.menu_changelog:
                 showMarkdownAsset(wvHelp, this, "changelog.md");
                 return true;
             case R.id.menu_myn:
-                showMarkdownAsset(wvHelp, this, "MYN.md");
+                showMarkdownAsset(wvHelp, this, "MYN" + getText(R.string.help_translation) + ".md");
                 return true;
             case R.id.menu_script:
-                showMarkdownAsset(wvHelp, this, "script.md");
+                showMarkdownAsset(wvHelp, this, "script" + getText(R.string.help_translation) + ".md");
                 return true;
             case R.id.menu_intents:
-                showMarkdownAsset(wvHelp, this, "intents.md");
+                showMarkdownAsset(wvHelp, this, "intents" + getText(R.string.help_translation) + ".md");
                 return true;
             case R.id.menu_ui:
-                showMarkdownAsset(wvHelp, this, "ui.md");
+                showMarkdownAsset(wvHelp, this, "ui" + getText(R.string.help_translation) + ".md");
                 return true;
             case R.id.menu_donate:
                 loadDesktop(wvHelp, "https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mpc%2ejanssen%40gmail%2ecom&lc=NL&item_name=mpcjanssen%2enl&item_number=Simpletask&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted");

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -226,5 +226,8 @@ Cualquier cambio que no haya sido sincronizado se perderá al abrir un archivo d
 
 <string name="hello_world">Hola mundo!</string>
 <string name="action_settings">Ajustes</string>
+<string name="help_translation">.es</string>
+    <string name="help_index">index.es.md</string>
+    <string name="help_add_task">addtask.es.md</string>
         </resources>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -356,4 +356,7 @@ You should have received a copy of the GNU General Public License along with Tod
 
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
+    <string name="help_translation"></string>
+    <string name="help_index"></string>
+    <string name="help_add_task"></string>
 </resources>


### PR DESCRIPTION
Dear Mark,

I was a bit surprised that you already had uploaded the strings.xml. Anyway, I translated the docs as well. To enable this I modified some of the code (java) files. I tried to stick to minimal modifications. A more general approach was possible but you are the one able to decide which is the best strategy for i8n.
For now: In strings.xml, a string can indicate which help file should be loaded. As the index help and the addtask help were "hardcoded" as constants, I had to superseed those with entries in strings.xml. The more general approach could be to use just the file name in the constants (without extension) and allow the language-specific tail to be added.
I hope that you like the solution. Let me know your thoughts.
Best,
Martin