### PR TITLE
Link to the topydo project rather than the (obsoleted) todo.txt-tools.

### DIFF
--- a/src/main/assets/index.en.md
+++ b/src/main/assets/index.en.md
@@ -13,7 +13,7 @@ Simpletask supports the following todo.txt extensions:
 
 -   Due date as `due:YYYY-MM-DD`
 -   Start/threshold date as `t:YYYY-MM-DD`
--   Recurrence with `rec:\+?[0-9]+[dwmy]` as described [here](https://github.com/bram85/todo.txt-tools/wiki/Recurrence) but with a twist.
+-   Recurrence with `rec:\+?[0-9]+[dwmy]` as described [here](https://github.com/bram85/topydo/wiki/Recurrence) but with a twist.
     - By default Simpletask will use the date of completion for recurring as described in the link. However if the rec includes a plus (e.g. `rec:+2w`), the date is determined from the original due or threshold date..
     - The format is described by a regular expression, so in words the syntax is `rec:` followed by an optional `+` then 1 or more numbers and then followed by one of `d`ay, `w`eek, `m`onth or `y`ear. For example `rec:12d` sets up a 12 day recurring task.
 - Hidden tasks with `h:1`, this allows dummy tasks with predefined lists and tags so that lists and tags will be available even if the last task with the tag/list is removed from `todo.txt`. These tasks will not be shown by default. You can temporarily display them from the Settings.

--- a/src/main/assets/index.es.md
+++ b/src/main/assets/index.es.md
@@ -13,7 +13,7 @@ Simpletask soporta las siguientes extensiones de todo.txt:
 
 -   Fecha de vencimiento: `due:YYYY-MM-DD` (año-mes-día)
 -   Fecha umbral/de inicio: `t:YYYY-MM-DD`
--   Tareas recurrentes: `rec:[0-9]+[dwmy]` (días, semanas, meses, años) como se describe [aquí](https://github.com/bram85/todo.txt-tools/wiki/Recurrence) pero con alguna variación.
+-   Tareas recurrentes: `rec:[0-9]+[dwmy]` (días, semanas, meses, años) como se describe [aquí](https://github.com/bram85/topydo/wiki/Recurrence) pero con alguna variación.
     - De forma predeterminada Simpletask utilizará las fechas originales de la tarea para crear la tarea recurrente, no la fecha de conclusión como se describe en el enlace. Este comportamiento puede ser configurado de los Ajustes.
     - La descripción del formato unas lineas más arriba es una [expresión regular](http://es.wikipedia.org/wiki/Expresi%C3%B3n_regular), o sea, que en lenguaje humano la sintaxis es `rec:` seguido de 1 o más números (el `+`) seguido por una de las siguientes `d` día, `w` semana, `m` mes o `y` año. Por ejemplo `rec:12d` especifica una tarea recurrente cada 12 días.
 - Tareas escondidas: `h:1`, esto permite tareas ficticias asignadas a listas y etiquetas predefinidas de modo que las mismas esten disponibles incluso si la última tarea que las contenía se borra del archivo `todo.txt`. Estas tareas no serán mostradas de forma predeterminada. Temporalmente se pueden mostrar usando los Ajustes.


### PR DESCRIPTION
todo.txt-tools has been obsoleted by my other project, topydo. Change the links to the (same) description of the topydo project.