### PR TITLE
Implemented ellipsizing support for task texts

### DIFF
--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.java
@@ -10,12 +10,16 @@
 package nl.mpcjanssen.simpletask;
 
 import android.annotation.SuppressLint;
-
 import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.SearchManager;
-import android.content.*;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
@@ -29,17 +33,48 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.widget.DrawerLayout;
-
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AlertDialog;
-
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
 import android.text.SpannableString;
+import android.text.TextUtils;
+import android.view.ActionMode;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AbsListView;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.BaseAdapter;
+import android.widget.CheckBox;
+import android.widget.DatePicker;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.PopupMenu;
+import android.widget.SearchView;
+import android.widget.TextView;
 
-import android.view.*;
-import android.widget.*;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+
 import hirondelle.date4j.DateTime;
 import nl.mpcjanssen.simpletask.adapters.DrawerAdapter;
 import nl.mpcjanssen.simpletask.remote.FileStoreInterface;
@@ -49,10 +84,6 @@ import nl.mpcjanssen.simpletask.task.TodoList;
 import nl.mpcjanssen.simpletask.task.token.Token;
 import nl.mpcjanssen.simpletask.util.Strings;
 import nl.mpcjanssen.simpletask.util.Util;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.*;
 
 
 public class Simpletask extends ThemedActivity implements
@@ -1428,6 +1459,8 @@ public class Simpletask extends ThemedActivity implements
                         .inFileFormat());
                 holder.tasktext.setText(ss);
 
+                handleEllipsizing(holder.tasktext);
+
                 if (task.isCompleted()) {
                     // log.info( "Striking through " + task.getText());
                     holder.tasktext.setPaintFlags(holder.tasktext
@@ -1529,6 +1562,40 @@ public class Simpletask extends ThemedActivity implements
             }
             VisibleLine line = visibleLines.get(position);
             return !line.header;
+        }
+    }
+
+    private void handleEllipsizing(TextView tasktext) {
+        final String no_ellipsize_value = "no_ellipsize";
+        final String ellipsizingPref = TodoApplication.getPrefs().getString("ellipsizing", no_ellipsize_value);
+
+        if (!no_ellipsize_value.equals(ellipsizingPref)) {
+            final TextUtils.TruncateAt truncateAt;
+            switch (ellipsizingPref) {
+                case "start":
+                    truncateAt = TextUtils.TruncateAt.START;
+                    break;
+                case "end":
+                    truncateAt = TextUtils.TruncateAt.END;
+                    break;
+                case "middle":
+                    truncateAt = TextUtils.TruncateAt.MIDDLE;
+                    break;
+                case "marquee":
+                    truncateAt = TextUtils.TruncateAt.MARQUEE;
+                    break;
+                default:
+                    truncateAt = null;
+                    break;
+            }
+
+            if (truncateAt != null) {
+                tasktext.setMaxLines(1);
+                tasktext.setHorizontallyScrolling(true);
+                tasktext.setEllipsize(truncateAt);
+            } else {
+                log.warn("Unrecognized preference value for task text ellipsizing: \"" + ellipsizingPref + "\"!");
+            }
         }
     }
 

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.java
@@ -1566,10 +1566,11 @@ public class Simpletask extends ThemedActivity implements
     }
 
     private void handleEllipsizing(TextView tasktext) {
-        final String no_ellipsize_value = "no_ellipsize";
-        final String ellipsizingPref = TodoApplication.getPrefs().getString("ellipsizing", no_ellipsize_value);
+        final String noEllipsizeValue = "no_ellipsize";
+        final String ellipsizingKey = TodoApplication.getAppContext().getString(R.string.task_text_ellipsizing_pref_key);
+        final String ellipsizingPref = TodoApplication.getPrefs().getString(ellipsizingKey, noEllipsizeValue);
 
-        if (!no_ellipsize_value.equals(ellipsizingPref)) {
+        if (!noEllipsizeValue.equals(ellipsizingPref)) {
             final TextUtils.TruncateAt truncateAt;
             switch (ellipsizingPref) {
                 case "start":
@@ -1594,7 +1595,7 @@ public class Simpletask extends ThemedActivity implements
                 tasktext.setHorizontallyScrolling(true);
                 tasktext.setEllipsize(truncateAt);
             } else {
-                log.warn("Unrecognized preference value for task text ellipsizing: \"" + ellipsizingPref + "\"!");
+                log.warn("Unrecognized preference value for task text ellipsizing: {} !", ellipsizingPref);
             }
         }
     }

--- a/src/main/res/values/donottranslate.xml
+++ b/src/main/res/values/donottranslate.xml
@@ -119,6 +119,7 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="font_size_delta_pref_key">fontsizedelta</string>
     <string name="theme_pref_key">theme</string>
     <string name="widget_theme_pref_key">widget_theme</string>
+    <string name="task_text_ellipsizing_pref_key">task_text_ellipsizing</string>
     <string name="widget_extended_pref_key">widget_extended</string>
     <string name="dropbox_cat_key">dropbox_category</string>
     <string name="behavior_cat_key">behavior_category</string>

--- a/src/main/res/values/donottranslate.xml
+++ b/src/main/res/values/donottranslate.xml
@@ -87,6 +87,20 @@ You should have received a copy of the GNU General Public License along with Tod
         <item>large</item>
         <item>huge</item>
     </string-array>
+    <string-array name="task_text_ellipsizing">
+        <item>None: Very long task text</item>
+        <item>Start: ...task text</item>
+        <item>Middle: Very... text</item>
+        <item>End: Very long...</item>
+        <item>Marquee: Very long ta</item>
+    </string-array>
+    <string-array name="task_text_ellipsizing_values">
+        <item>no_ellipsize</item>
+        <item>start</item>
+        <item>middle</item>
+        <item>end</item>
+        <item>marquee</item>
+    </string-array>
 
 
     <!-- Unlocalized Help names -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -167,6 +167,9 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="widget_theme_pref_title">Widget theme</string>
     <string name="widget_theme_pref_summary">Change the theme used for the widgets.</string>
 
+    <string name="task_text_ellipsizing_pref_title">Task text ellipsizing</string>
+    <string name="task_text_ellipsizing_pref_summary">Ellipsize task text in main window if it takes more than 2 lines.</string>
+
     <string name="widget_header_transparency_title">Widget header transparency</string>
     <string name="widget_background_transparency_title">Widget background transparency</string>
 

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -58,7 +58,7 @@
             android:defaultValue="no_ellipsize"
             android:entries="@array/task_text_ellipsizing"
             android:entryValues="@array/task_text_ellipsizing_values"
-            android:key="ellipsizing"
+            android:key="@string/task_text_ellipsizing_pref_key"
             android:summary="@string/task_text_ellipsizing_pref_summary"
             android:title="@string/task_text_ellipsizing_pref_title"/>
 

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -54,6 +54,13 @@
                 android:key="@string/widget_theme_pref_key"
                 android:summary="@string/widget_theme_pref_summary"
                 android:title="@string/widget_theme_pref_title"/>
+        <ListPreference
+            android:defaultValue="no_ellipsize"
+            android:entries="@array/task_text_ellipsizing"
+            android:entryValues="@array/task_text_ellipsizing_values"
+            android:key="ellipsizing"
+            android:summary="@string/task_text_ellipsizing_pref_summary"
+            android:title="@string/task_text_ellipsizing_pref_title"/>
 
         <com.robobunny.SeekBarPreference xmlns:robobunny="http://robobunny.com"
                                          android:key="@string/widget_header_transparency"


### PR DESCRIPTION
I would like to see this option in the app. Basically if the user selects one of the options, the task will be shortened to one line.
An example use case is when I have a long URL in the task text prefixed with a short summary, e.g.: "Learn about the Proxy deisgn pattern: http://verylongurl.com".
Please review and consider pulling.