### PR TITLE
Calendar sync: Don't prefix event titles any more

### DIFF
--- a/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
+++ b/src/main/java/nl/mpcjanssen/simpletask/CalendarSync.java
@@ -138,7 +138,7 @@ public class CalendarSync {
     }
 
     @SuppressWarnings("NewApi")
-    private void insertEvt(long calID, DateTime date, String titlePrefix, String title) {
+    private void insertEvt(long calID, DateTime date, String title, String description) {
         ContentValues values = new ContentValues();
 
         TimeZone localZone = Calendar.getInstance().getTimeZone();
@@ -146,11 +146,11 @@ public class CalendarSync {
 
         // Event:
         values.put(Events.CALENDAR_ID, calID);
-        values.put(Events.TITLE, titlePrefix+' '+title);
+        values.put(Events.TITLE, title);
         values.put(Events.DTSTART, dtstart);
         values.put(Events.DTEND, dtstart + EVT_DURATION_DAY);  // Needs to be set to DTSTART +24h, otherwise reminders don't work
         values.put(Events.ALL_DAY, 1);
-        values.put(Events.DESCRIPTION, m_app.getString(R.string.calendar_sync_evt_desc));
+        values.put(Events.DESCRIPTION, description);
         values.put(Events.EVENT_TIMEZONE, UTC.getID());
         values.put(Events.STATUS, Events.STATUS_CONFIRMED);
         values.put(Events.HAS_ATTENDEE_DATA, true);      // If this is not set, Calendar app is confused about Event.STATUS
@@ -185,7 +185,7 @@ public class CalendarSync {
                 dt = task.getDueDate();
                 if (dt != null) {
                     text = task.getText();
-                    insertEvt(calID, dt, m_app.getString(R.string.calendar_sync_prefix_due), text);
+                    insertEvt(calID, dt, text, m_app.getString(R.string.calendar_sync_desc_due));
                 }
             }
 
@@ -194,7 +194,7 @@ public class CalendarSync {
                 dt = task.getThresholdDate();
                 if (dt != null) {
                     if (text == null) text = task.getText();
-                    insertEvt(calID, dt, m_app.getString(R.string.calendar_sync_prefix_thre), text);
+                    insertEvt(calID, dt, text, m_app.getString(R.string.calendar_sync_desc_thre));
                 }
             }
         }

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -344,9 +344,8 @@ You should have received a copy of the GNU General Public License along with Tod
 
     <!-- Calendar sync -->
     <string name="calendar_disp_name">Simpletask Erinnerungen</string>
-    <string name="calendar_sync_prefix_due">Fälligkeitsdatum:</string>
-    <string name="calendar_sync_prefix_thre">Anfangsdatum:</string>
-    <string name="calendar_sync_evt_desc">Automatisch erstellt von Simpletask</string>
+    <string name="calendar_sync_desc_due">Fälligkeitsdatum Erinnerung, automatisch erstellt von Simpletask</string>
+    <string name="calendar_sync_desc_thre">Anfangsdatum Erinnerung, automatisch erstellt von Simpletask</string>
     <string name="calendar_exists_warning">Warnung: ein Kalender identischen Namens existiert bereits. Überschreibe...</string>
 
  <string name="click_to_copy">Tippen, um in die Zwischenablage zu kopieren.</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -212,9 +212,8 @@ Cualquier cambio que no haya sido sincronizado se perderá al abrir un archivo d
 
         <!-- Calendar sync -->
 <string name="calendar_disp_name">Recordatorios Simpletask</string>
-<string name="calendar_sync_prefix_due">Vencimiento de tarea:</string>
-<string name="calendar_sync_prefix_thre">Umbral de tarea:</string>
-<string name="calendar_sync_evt_desc">Generado automáticamente por Simpletask</string>
+<string name="calendar_sync_desc_due">Due date reminder, generated automatically by Simpletask</string>
+<string name="calendar_sync_desc_thre">Threshold date reminder, generated automatically by Simpletask</string>
 <string name="calendar_exists_warning">Aviso: Ya existe un calendario con el mismo nombre, sobreescribiendolo…</string>
 
 <string name="click_to_copy">Clic para copiar al portapapeles.</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -334,9 +334,8 @@ You should have received a copy of the GNU General Public License along with Tod
     <!-- Calendar sync -->
     <!--TODO: translate-->
     <string name="calendar_disp_name">Simpletask Reminders</string>
-    <string name="calendar_sync_prefix_due">Task due:</string>
-    <string name="calendar_sync_prefix_thre">Task threshold:</string>
-    <string name="calendar_sync_evt_desc">Generated automatically by Simpletask</string>
+    <string name="calendar_sync_desc_due">Due date reminder, generated automatically by Simpletask</string>
+    <string name="calendar_sync_desc_thre">Threshold date reminder, generated automatically by Simpletask</string>
     <string name="calendar_exists_warning">Warning: Calendar with the same name already exists, overwriting...</string>
 
     <string name="click_to_copy">Click to copy to clipboard.</string>

--- a/src/main/res/values-ko/strings.xml
+++ b/src/main/res/values-ko/strings.xml
@@ -301,9 +301,8 @@
 
     <!-- Calendar sync -->
     <string name="calendar_disp_name">심플태스크 알림</string>
-    <string name="calendar_sync_prefix_due">일정 마감일:</string>
-    <string name="calendar_sync_prefix_thre">일정 시작일:</string>
-    <string name="calendar_sync_evt_desc">심플태스크가 자동 생성함</string>
+    <string name="calendar_sync_desc_due">Due date reminder, generated automatically by Simpletask</string>
+    <string name="calendar_sync_desc_thre">Threshold date reminder, generated automatically by Simpletask</string>
     <string name="calendar_exists_warning">경고: 같은 이름의 달력이 이미 존재함, 덮어쓰는중…</string>
 
     <string name="click_to_copy">클립보드에 복사하려면 선택</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -374,9 +374,8 @@ You should have received a copy of the GNU General Public License along with Tod
 
     <!-- Calendar sync -->
     <string name="calendar_disp_name">Simpletask Reminders</string>
-    <string name="calendar_sync_prefix_due">Task due:</string>
-    <string name="calendar_sync_prefix_thre">Task threshold:</string>
-    <string name="calendar_sync_evt_desc">Generated automatically by Simpletask</string>
+    <string name="calendar_sync_desc_due">Due date reminder, generated automatically by Simpletask</string>
+    <string name="calendar_sync_desc_thre">Threshold date reminder, generated automatically by Simpletask</string>
     <string name="calendar_exists_warning">Warning: Calendar with the same name already exists, overwriting...</string>
 
     <string name="click_to_copy">Click to copy to clipboard.</string>


### PR DESCRIPTION
It makes calendar view unnecessarily messy, I don't know why I did this in the first place...

![prefixed tasks](https://i.imgur.com/tSvvvUv.png)
