### PR TITLE
Fix drawers background to match current theme

### DIFF
--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -147,6 +147,12 @@ class Simpletask : ThemedActivity(), AbsListView.OnScrollListener, AdapterView.O
         if (m_app.isDarkTheme) {
             val actionBarClear = findViewById(R.id.actionbar_clear) as ImageView?
             actionBarClear?.setImageResource(R.drawable.ic_action_content_clear)
+        } else {
+            val btnFilterAdd = findViewById(R.id.btn_filter_add) as ImageButton?
+            btnFilterAdd?.setColorFilter(resources.getColor(android.R.color.holo_blue_dark, null));
+
+            val btnFilterImport = findViewById(R.id.btn_filter_import) as ImageButton?
+            btnFilterImport?.setColorFilter(resources.getColor(android.R.color.holo_blue_dark, null));
         }
 
     }

--- a/src/main/res/layout/drawer_list_item.xml
+++ b/src/main/res/layout/drawer_list_item.xml
@@ -23,5 +23,4 @@
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
     android:background="?android:attr/activatedBackgroundIndicator"
-    android:minHeight="?android:attr/listPreferredItemHeightSmall"
-    android:textColor="@android:color/white" />
+    android:minHeight="?android:attr/listPreferredItemHeightSmall" />

--- a/src/main/res/layout/drawer_list_item_checked.xml
+++ b/src/main/res/layout/drawer_list_item_checked.xml
@@ -23,5 +23,4 @@
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
     android:checkMark="?android:attr/listChoiceIndicatorMultiple"
-    android:minHeight="?android:attr/listPreferredItemHeightSmall"
-    android:textColor="@android:color/white" />
+    android:minHeight="?android:attr/listPreferredItemHeightSmall" />

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -112,7 +112,7 @@
         android:layout_width="match_parent"
         android:layout_height="fill_parent"
         android:layout_gravity="start"
-        android:background="#111"
+        android:background="?android:colorBackground"
         android:choiceMode="multipleChoice"
         android:divider="@android:color/transparent"
         android:dividerHeight="0dp" />
@@ -123,7 +123,7 @@
         android:layout_width="match_parent"
         android:layout_height="fill_parent"
         android:layout_gravity="end"
-        android:background="#111"
+        android:background="?android:colorBackground"
         android:orientation="vertical">
 
         <TextView


### PR DESCRIPTION
When using light theme, the drawer background stays dark. To fix this I changed to use the colors from current theme in the drawer background and text.
![lighttheme](https://cloud.githubusercontent.com/assets/11561593/16175039/31bcb4ba-35b7-11e6-906c-96bb0f92ecb8.png)
![darktheme](https://cloud.githubusercontent.com/assets/11561593/16175040/32bf1376-35b7-11e6-8802-699174a6862a.png)


