### PR TITLE
revert unintended change

### DIFF
--- a/src/main/res/layout/appwidget.xml
+++ b/src/main/res/layout/appwidget.xml
@@ -48,6 +48,7 @@
             android:contentDescription="@string/addtask"
             android:enabled="true"
             
+            android:icon="@drawable/ic_add_white_24dp"
             android:src="@drawable/ic_add_white_24dp" />
 
     </LinearLayout>


### PR DESCRIPTION
Accidentally removed in #537. Removing it had no visible effect on the emulated nexus 5x running android N, but let's not find out if it breaks something else right now.