### PR TITLE
WIP: Debug builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ android {
         exclude 'LICENSE.txt'
     }
 
-
     defaultConfig {
         versionName '8.2.2'
         versionCode 3047
@@ -51,6 +50,11 @@ android {
     }
 
     buildTypes {
+    
+        debug {
+            applicationIdSuffix '.debug'
+            versionNameSuffix '-DEBUG'
+        }
         release {
             //noinspection GroovyAssignabilityCheck
             signingConfig signingConfigs.release


### PR DESCRIPTION
There's a build error about a conflicting provider. I'm not sure exactly how to solve that.

Should also change the icon (suggestion: recolor it) and/or app name (suggestion: "Simpletask-DEBUG" for debug builds).

I wasn't sure how to do that since the project structure isn't the default, so there isn't a folder where I can put resources for debug builds. That I know of, anyway.