### PR TITLE
Pebble App Integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     compile 'com.github.rjeschke:txtmark:0.11'
     compile 'com.darwinsys:hirondelle-date4j:1.5.1'
     compile 'org.luaj:luaj-jse:3.0.1'
+    compile 'com.getpebble:pebblekit:3.1.0@aar'
     testCompile 'junit:junit:4.12'
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
     androidTestCompile('com.android.support.test:runner:0.5') {

--- a/src/main/java/nl/mpcjanssen/simpletask/PebbleAckReceiver.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/PebbleAckReceiver.kt
@@ -1,0 +1,24 @@
+package nl.mpcjanssen.simpletask
+
+import android.content.Context
+import com.getpebble.android.kit.PebbleKit
+import java.util.*
+
+/**
+ * Created by brandonknitter on 10/9/16.
+ */
+
+class PebbleAckReceiver(subscribedUuid: UUID?) : PebbleKit.PebbleAckReceiver(subscribedUuid) {
+    private var log = Logger
+
+    override fun receiveAck(context: Context?, transactionId: Int) {
+        log.debug(TAG, "ack from pebble: "+transactionId);
+        if (transactionId==42)
+            PebbleReceiver.sendNextTask(context);
+    }
+
+    companion object {
+        private val TAG = "PebbleAckReceiver"
+    }
+
+}

--- a/src/main/java/nl/mpcjanssen/simpletask/PebbleNackReceiver.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/PebbleNackReceiver.kt
@@ -1,0 +1,22 @@
+package nl.mpcjanssen.simpletask
+
+import android.content.Context
+import com.getpebble.android.kit.PebbleKit
+import java.util.*
+
+/**
+ * Created by brandonknitter on 10/9/16.
+ */
+
+class PebbleNackReceiver(subscribedUuid: UUID?) : PebbleKit.PebbleNackReceiver(subscribedUuid) {
+    private var log = Logger
+
+    override fun receiveNack(context: Context?, transactionId: Int) {
+        log.debug(TAG, "nack from pebble: "+transactionId);
+    }
+
+    companion object {
+        private val TAG = "PebbleNackReceiver"
+    }
+
+}

--- a/src/main/java/nl/mpcjanssen/simpletask/PebbleReceiver.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/PebbleReceiver.kt
@@ -1,0 +1,89 @@
+package nl.mpcjanssen.simpletask
+
+import android.content.Context
+import com.getpebble.android.kit.PebbleKit
+import com.getpebble.android.kit.PebbleKit.PebbleAckReceiver
+import com.getpebble.android.kit.PebbleKit.PebbleDataReceiver
+import com.getpebble.android.kit.util.PebbleDictionary
+import nl.mpcjanssen.simpletask.task.TToken
+import nl.mpcjanssen.simpletask.task.TodoList
+import java.util.*
+
+/**
+ * Created by brandonknitter on 10/5/16.
+ */
+
+
+class PebbleReceiver(subscribedUuid: UUID?) : PebbleDataReceiver(subscribedUuid) {
+
+
+    override fun receiveData(context: Context?, transactionId: Int, data: PebbleDictionary?) {
+        log.debug(TAG, "receiveData...")
+
+        val messageTypeRequest = data?.getInteger(0); // hardcoded to be field 0
+
+        PebbleKit.sendAckToPebble(context, transactionId);
+
+        when(messageTypeRequest) {
+            MessageTypeRequestAllTasks -> requestAllTasks(context, transactionId, data)
+            else -> log.debug(TAG, "Bad requestType: " + messageTypeRequest)
+        }
+
+    }
+
+    fun requestAllTasks(context: Context?, transactionId: Int, data: PebbleDictionary?) {
+        val pebbleIsConnected = PebbleKit.isWatchConnected(context)
+        val pebbleAppMessageSupported = PebbleKit.areAppMessagesSupported(context)
+        log.debug(TAG, "Is watch connected? " + pebbleIsConnected)
+        log.debug(TAG, "Is message supported? " + pebbleAppMessageSupported)
+
+        nextTask=0;
+        sendNextTask(context);
+
+    }
+
+    companion object {
+        val appUuid = UUID.fromString("a6c5b8ef-0b0e-4db2-8ebe-32a363699065")
+
+        val log = Logger
+
+        @JvmStatic var nextTask=0;
+        @JvmStatic fun sendNextTask(context: Context?) {
+            if (TodoList.todoItems.size <= nextTask) {
+                log.debug(TAG, "No more tasks to send at "+ nextTask);
+                return;
+            }
+            val item=TodoList.todoItems.get(nextTask);
+            nextTask++;
+
+            val dict = PebbleDictionary()
+
+            // just get the text portion out for now
+            val tokensToShow = TToken.ALL and TToken.TEXT
+            // TODO(bk) need to trim this to a maximum length
+            val text = item.task.showParts(tokensToShow)
+
+            dict.addInt32(0, MessageTypeResponseTask);
+            dict.addInt32(MessageTypeResponseTaskLine, item.line.toInt());
+            dict.addString(MessageTypeResponseTaskName, text)
+
+            log.debug(TAG, "Sending task: " + item.line + "=" + text+" with UUID: "+ appUuid);
+            PebbleKit.sendDataToPebbleWithTransactionId(context, appUuid, dict, 42)
+        }
+
+
+        // Watch to Phone request types (field 0)
+        val MessageTypeRequestAllTasks:Long=0;
+        val MessageTypeRequestCompleteTask=1;
+
+        // Phone to Watch Response Types (field 0)
+        val MessageTypeResponseTask=0;
+
+        // Fields: MessageTypeResponseTask=0
+        val MessageTypeResponseTaskLine=1;
+        val MessageTypeResponseTaskName=2;
+
+        private val TAG = "PebbleReceiver"
+    }
+
+}

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -41,6 +41,7 @@ import android.view.*
 import android.view.inputmethod.InputMethodManager
 import android.widget.*
 import android.widget.AdapterView.OnItemLongClickListener
+import com.getpebble.android.kit.PebbleKit
 import hirondelle.date4j.DateTime
 import nl.mpcjanssen.simpletask.adapters.DrawerAdapter
 import nl.mpcjanssen.simpletask.adapters.ItemDialogAdapter
@@ -84,6 +85,8 @@ class Simpletask : ThemedNoActionBarActivity() {
     private var m_drawerToggle: ActionBarDrawerToggle? = null
     private var m_savedInstanceState: Bundle? = null
     internal var m_scrollPosition = 0
+
+    // Pebble
 
     private var log = Logger
 
@@ -408,6 +411,12 @@ class Simpletask : ThemedNoActionBarActivity() {
 
     override fun onResume() {
         super.onResume()
+
+        // register Pebble handlers
+        PebbleKit.registerReceivedDataHandler(applicationContext, pebbleReceiver)
+        PebbleKit.registerReceivedAckHandler(applicationContext, pebbleAckReceiver)
+        PebbleKit.registerReceivedNackHandler(applicationContext, pebbleNackReceiver)
+
         FileStore.pause(false)
         handleIntent()
     }
@@ -1660,5 +1669,9 @@ class Simpletask : ThemedNoActionBarActivity() {
         val URI_BASE = Uri.fromParts("Simpletask", "", null)!!
         val URI_SEARCH = Uri.withAppendedPath(URI_BASE, "search")!!
         private val TAG = "Simpletask"
+
+        private val pebbleReceiver = PebbleReceiver(PebbleReceiver.appUuid)
+        private val pebbleAckReceiver = PebbleAckReceiver(PebbleReceiver.appUuid)
+        private val pebbleNackReceiver = PebbleNackReceiver(PebbleReceiver.appUuid)
     }
 }


### PR DESCRIPTION
This provides functionality so that a Pebble app can communicate with SimpleTask.  The hooks are registered broadcast receivers.  If the user doesn't have a Pebble watch there should be no impact.