### PR TITLE
always show selected tasks in the filter. fixes #627

### DIFF
--- a/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
@@ -53,6 +53,9 @@ class AddTask : ThemedActionBarActivity() {
         // Config.loadTodoList(true)
 
         val intent = intent
+        val isEdit = intent.getBooleanExtra(Constants.EXTRA_EDIT, false)
+        if (!isEdit) TodoList.clearSelection()
+
         val mFilter = ActiveFilter(FilterOptions(luaModule = "addtask"))
         mFilter.initFromIntent(intent)
 

--- a/src/main/java/nl/mpcjanssen/simpletask/Constants.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Constants.kt
@@ -58,6 +58,8 @@ object Constants {
     const val EXTRA_WIDGET_RECONFIGURE = "widgetreconfigure"
     const val EXTRA_WIDGET_ID = "widgetid"
 
+    const val EXTRA_EDIT = "editing"
+
     // Android OS specific constants
     const val ANDROID_EVENT = "vnd.android.cursor.item/event"
 

--- a/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
@@ -199,14 +199,15 @@ class FilterActivity : ThemedNoActionBarActivity() {
                 finish()
                 return true
             }
-            R.id.menu_filter_action -> if (asWidgetConfigure) {
-                askWidgetName()
-            } else if (asWidgetReConfigure) {
-                updateWidget()
-                finish()
-            } else {
-                applyFilter()
-            }
+            R.id.menu_filter_action ->
+                if (asWidgetConfigure) {
+                    askWidgetName()
+                } else if (asWidgetReConfigure) {
+                    updateWidget()
+                    finish()
+                } else {
+                    applyFilter()
+                }
             R.id.menu_filter_load_script -> openScript(object : FileStoreInterface.FileReadListener {
                 override fun fileRead(contents: String?) {
                     runOnMainThread(

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -1020,8 +1020,8 @@ class Simpletask : ThemedNoActionBarActivity() {
             mFilter!!.saveInIntent(intent)
             setIntent(intent)
             mFilter!!.saveInPrefs(Config.prefs)
-            m_adapter!!.setFilteredTasks()
             closeDrawer(NAV_DRAWER)
+            closeSelectionMode()
             updateDrawers()
         }
         m_navDrawerList!!.onItemLongClickListener = OnItemLongClickListener { parent, view, position, id ->

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -59,8 +59,10 @@ import java.io.IOException
 import java.util.*
 import android.R.id as androidId
 
-
 class Simpletask : ThemedNoActionBarActivity() {
+
+    private const val EDIT: Boolean = true
+    private const val ADD: Boolean = false
 
     enum class Mode {
         NAV_DRAWER, FILTER_DRAWER, SELECTION, MAIN
@@ -296,6 +298,7 @@ class Simpletask : ThemedNoActionBarActivity() {
         // Show search or filter results
         val intent = intent
         if (Constants.INTENT_START_FILTER == intent.action) {
+            TodoList.clearSelection()
             mFilter!!.initFromIntent(intent)
             log.info(TAG, "handleIntent: launched with filter" + mFilter!!)
             val extras = intent.extras
@@ -351,7 +354,7 @@ class Simpletask : ThemedNoActionBarActivity() {
         }
 
         val fab = findViewById(R.id.fab) as FloatingActionButton
-        fab.setOnClickListener { startAddTaskActivity() }
+        fab.setOnClickListener { startAddTaskActivity(ADD) }
         invalidateOptionsMenu()
         updateDrawers()
     }
@@ -778,7 +781,7 @@ class Simpletask : ThemedNoActionBarActivity() {
             R.id.history -> startActivity(Intent(this, HistoryScreen::class.java))
             R.id.btn_filter_add -> onAddFilterClick()
             R.id.clear_filter -> clearFilter()
-            R.id.update -> startAddTaskActivity()
+            R.id.update -> startAddTaskActivity(EDIT)
             R.id.defer_due -> deferTasks(checkedTasks, DateType.DUE)
             R.id.defer_threshold -> deferTasks(checkedTasks, DateType.THRESHOLD)
             R.id.priority -> prioritizeTasks(checkedTasks)
@@ -822,9 +825,10 @@ class Simpletask : ThemedNoActionBarActivity() {
         startActivity(intent)
     }
 
-    private fun startAddTaskActivity() {
+    private fun startAddTaskActivity(isEdit: Boolean) {
         log.info(TAG, "Starting addTask activity")
         val intent = Intent(this, AddTask::class.java)
+        intent.putExtra(Constants.EXTRA_EDIT, isEdit)
         mFilter!!.saveInIntent(intent)
         startActivity(intent)
     }

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -848,7 +848,7 @@ class Simpletask : ThemedNoActionBarActivity() {
             val filterIds = saved_filter_ids.getStringSet("ids", HashSet<String>())
             for (id in filterIds) {
                 val filter_pref = getSharedPreferences(id, Context.MODE_PRIVATE)
-                val filter = ActiveFilter(FilterOptions(luaModule = "mainui"))
+                val filter = ActiveFilter(FilterOptions(luaModule = "mainui", showSelected = true))
                 filter.initFromPrefs(filter_pref)
                 filter.prefName = id
                 saved_filters.add(filter)
@@ -862,7 +862,7 @@ class Simpletask : ThemedNoActionBarActivity() {
                 val contents = FileStore.readFile(importFile.canonicalPath, null)
                 val jsonFilters = JSONObject(contents)
                 jsonFilters.keys().forEach {
-                    val filter = ActiveFilter(FilterOptions(luaModule = "mainui"))
+                    val filter = ActiveFilter(FilterOptions(luaModule = "mainui", showSelected = true))
                     filter.initFromJSON(jsonFilters.getJSONObject(it))
                     saveFilterInPrefs(it,filter)
                 }
@@ -1071,7 +1071,7 @@ class Simpletask : ThemedNoActionBarActivity() {
         ids.remove(prefsName)
         saved_filters.edit().putStringSet("ids", ids).apply()
         val filter_prefs = getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        val deleted_filter = ActiveFilter(FilterOptions(luaModule = "mainui"))
+        val deleted_filter = ActiveFilter(FilterOptions(luaModule = "mainui", showSelected = true))
         deleted_filter.initFromPrefs(filter_prefs)
         filter_prefs.edit().clear().apply()
         val prefs_path = File(this.filesDir, "../shared_prefs")
@@ -1085,7 +1085,7 @@ class Simpletask : ThemedNoActionBarActivity() {
 
     private fun updateSavedFilter(prefsName: String) {
         val filter_pref = getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        val old_filter = ActiveFilter(FilterOptions(luaModule = "mainui"))
+        val old_filter = ActiveFilter(FilterOptions(luaModule = "mainui", showSelected = true))
         old_filter.initFromPrefs(filter_pref)
         val filterName = old_filter.name
         mFilter!!.name = filterName
@@ -1095,7 +1095,7 @@ class Simpletask : ThemedNoActionBarActivity() {
 
     private fun renameSavedFilter(prefsName: String) {
         val filter_pref = getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        val old_filter = ActiveFilter(FilterOptions(luaModule = "mainui"))
+        val old_filter = ActiveFilter(FilterOptions(luaModule = "mainui", showSelected = true))
         old_filter.initFromPrefs(filter_pref)
         val filterName = old_filter.name
         val alert = AlertDialog.Builder(this)

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -59,6 +59,7 @@ import java.io.IOException
 import java.util.*
 import android.R.id as androidId
 
+
 class Simpletask : ThemedNoActionBarActivity() {
 
     private const val EDIT: Boolean = true

--- a/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
@@ -242,6 +242,7 @@ object TodoList {
         ActionQueue.add("Add/Edit tasks", Runnable {
             log.info(TAG, "Starting addTask activity")
             val intent = Intent(act, AddTask::class.java)
+            intent.putExtra(Constants.EXTRA_EDIT, true) //true ->  edit, not add
             act.startActivity(intent)
         })
     }


### PR DESCRIPTION
Turns out when the active filter was changed, it wasn't loading with `showSelected = true`. Now it does.