### PR TITLE
soft code colors and add due:tomorrow

### DIFF
--- a/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
@@ -138,11 +138,11 @@ data class AppWidgetRemoteViewsFactory(val intent: Intent) : RemoteViewsService.
 
         val prioColor: Int
         when (task.priority) {
-            Priority.A -> prioColor = ContextCompat.getColor(TodoApplication.app,android.R.color.holo_red_dark)
-            Priority.B -> prioColor = ContextCompat.getColor(TodoApplication.app,android.R.color.holo_orange_dark)
-            Priority.C -> prioColor = ContextCompat.getColor(TodoApplication.app,android.R.color.holo_green_dark)
-            Priority.D -> prioColor = ContextCompat.getColor(TodoApplication.app,android.R.color.holo_blue_dark)
-            else -> prioColor = ContextCompat.getColor(TodoApplication.app,android.R.color.darker_gray)
+            Priority.A -> prioColor = ContextCompat.getColor(TodoApplication.app, R.color.simple_red_dark)
+            Priority.B -> prioColor = ContextCompat.getColor(TodoApplication.app, R.color.simple_orange_dark)
+            Priority.C -> prioColor = ContextCompat.getColor(TodoApplication.app, R.color.simple_green_dark)
+            Priority.D -> prioColor = ContextCompat.getColor(TodoApplication.app, R.color.simple_blue_dark)
+            else -> prioColor = ContextCompat.getColor(TodoApplication.app, R.color.gray67)
         }
         if (prioColor != 0) {
             setColor(ss, prioColor, task.priority.inFileFormat())
@@ -188,17 +188,17 @@ data class AppWidgetRemoteViewsFactory(val intent: Intent) : RemoteViewsService.
     }
 
     private fun itemForLightTheme(rv: RemoteViews) {
-        rv.setTextColor(R.id.tasktext, ContextCompat.getColor(TodoApplication.app,android.R.color.black))
-        rv.setTextColor(R.id.taskage, ContextCompat.getColor(TodoApplication.app,android.R.color.darker_gray))
-        rv.setTextColor(R.id.taskdue, ContextCompat.getColor(TodoApplication.app,android.R.color.darker_gray))
-        rv.setTextColor(R.id.taskthreshold, ContextCompat.getColor(TodoApplication.app,android.R.color.darker_gray))
+        rv.setTextColor(R.id.tasktext, ContextCompat.getColor(TodoApplication.app, R.color.black))
+        rv.setTextColor(R.id.taskage, ContextCompat.getColor(TodoApplication.app, R.color.gray67))
+        rv.setTextColor(R.id.taskdue, ContextCompat.getColor(TodoApplication.app, R.color.gray67))
+        rv.setTextColor(R.id.taskthreshold, ContextCompat.getColor(TodoApplication.app, R.color.gray67))
     }
 
     private fun itemForDarkTheme(rv: RemoteViews) {
-        rv.setTextColor(R.id.tasktext, ContextCompat.getColor(TodoApplication.app,android.R.color.white))
-        rv.setTextColor(R.id.taskage, ContextCompat.getColor(TodoApplication.app,android.R.color.darker_gray))
-        rv.setTextColor(R.id.taskdue, ContextCompat.getColor(TodoApplication.app,android.R.color.darker_gray))
-        rv.setTextColor(R.id.taskthreshold, ContextCompat.getColor(TodoApplication.app,android.R.color.darker_gray))
+        rv.setTextColor(R.id.tasktext, ContextCompat.getColor(TodoApplication.app, R.color.white))
+        rv.setTextColor(R.id.taskage, ContextCompat.getColor(TodoApplication.app, R.color.gray67))
+        rv.setTextColor(R.id.taskdue, ContextCompat.getColor(TodoApplication.app, R.color.gray67))
+        rv.setTextColor(R.id.taskthreshold, ContextCompat.getColor(TodoApplication.app, R.color.gray67))
     }
 
     override fun getViewAt(position: Int): RemoteViews? {

--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -1293,11 +1293,11 @@ class Simpletask : ThemedNoActionBarActivity() {
             val priorityColor: Int
             val priority = task.priority
             when (priority) {
-                Priority.A -> priorityColor = ContextCompat.getColor(m_app, android.R.color.holo_red_dark)
-                Priority.B -> priorityColor = ContextCompat.getColor(m_app, android.R.color.holo_orange_dark)
-                Priority.C -> priorityColor = ContextCompat.getColor(m_app, android.R.color.holo_green_dark)
-                Priority.D -> priorityColor = ContextCompat.getColor(m_app, android.R.color.holo_blue_dark)
-                else -> priorityColor = ContextCompat.getColor(m_app, android.R.color.darker_gray)
+                Priority.A -> priorityColor = ContextCompat.getColor(m_app, R.color.simple_red_dark)
+                Priority.B -> priorityColor = ContextCompat.getColor(m_app, R.color.simple_orange_dark)
+                Priority.C -> priorityColor = ContextCompat.getColor(m_app, R.color.simple_green_dark)
+                Priority.D -> priorityColor = ContextCompat.getColor(m_app, R.color.simple_blue_dark)
+                else -> priorityColor = ContextCompat.getColor(m_app, R.color.gray67)
             }
             setColor(ss, priorityColor, priority.inFileFormat())
             val completed = task.isCompleted()

--- a/src/main/java/nl/mpcjanssen/simpletask/util/Util.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/util/Util.kt
@@ -515,13 +515,10 @@ private fun getRelativeDate(app: TodoApplication, prefix: String, dateString: St
     val date = dateString.toDateTime() ?: return null
     val now = DateTime.today(TimeZone.getDefault())
     val days= date.numDaysFrom(now)
-
-    val months = days/ 31
-    val weeks = days/ 7
-    val years = days/ 365
-
+    val months = days/31
+    val weeks = days/7
+    val years = days/365
     val s = when {
-        !date.lteq(now) -> date.toString()
         years==1  -> app.getString(R.string.dates_one_year_ago)
         years>1   -> app.getString(R.string.dates_years_ago, years)
         months==1 -> app.getString(R.string.dates_one_month_ago)
@@ -531,17 +528,20 @@ private fun getRelativeDate(app: TodoApplication, prefix: String, dateString: St
         days==1   -> app.getString(R.string.dates_one_day_ago)
         days>1    -> app.getString(R.string.dates_days_ago, days)
         days==0   -> app.getString(R.string.dates_today)
+        days==-1   -> app.getString(R.string.dates_tomorrow)
         else      -> date.toString()
     }
 
     val ss = SpannableString(prefix + s)
 
     if (Config.hasColorDueDates && prefix=="Due: ") {
-        val dueTodayColor = ContextCompat.getColor(app, android.R.color.holo_green_light)
-        val overDueColor = ContextCompat.getColor(app, android.R.color.holo_red_light)
+        val dueTodayColor = ContextCompat.getColor(app, R.color.simple_green_light)
+        val overDueColor = ContextCompat.getColor(app, R.color.simple_red_light)
+        val dueTomorrowColor = ContextCompat.getColor(app, R.color.simple_blue_light)
         when {
             days==0        -> setColor(ss, dueTodayColor)
             date.lteq(now) -> setColor(ss, overDueColor)
+            days==-1       -> setColor(ss, dueTomorrowColor)
         }
     }
 

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -43,7 +43,7 @@
                     android:id="@+id/offline"
                     android:layout_width="match_parent"
                     android:layout_height="2dp"
-                    android:background="@android:color/holo_orange_light"
+                    android:background="@color/simple_orange_light"
                     android:visibility="gone"
                     android:elevation="3dp"
                     tools:ignore="UnusedAttribute"

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -14,4 +14,14 @@
     <color name="gray87">#ff212121</color>
     <color name="gray81">#ff303030</color>
     <color name="gray74">#ff424242</color>
+    <color name="gray67">#ffaaaaaa</color>
+
+    <color name="simple_blue_dark">#ff0099cc</color>
+    <color name="simple_blue_light">#ff33b5e5</color>
+    <color name="simple_green_light">#ff99cc00</color>
+    <color name="simple_green_dark">#ff669900</color>
+    <color name="simple_orange_light">#ffffbb33</color>
+    <color name="simple_orange_dark">#ffff8800</color>
+    <color name="simple_red_light">#ffff4444</color>
+    <color name="simple_red_dark">#ffcc0000</color>
 </resources>


### PR DESCRIPTION
Use colors defined from `colors.xml` rather than `android.R.color.holo_something`. So far all the colors are the exact same as before, this just frees us to change them later if we desire.

Then fix due dates so `due:tomorrow` shows again and color `due:tomorrow` light blue.