### PR TITLE
refilter tasks when unselecting for #627

### DIFF
--- a/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -1389,6 +1389,7 @@ class Simpletask : ThemedNoActionBarActivity() {
                     TodoList.selectTodoItem(item)
                 } else {
                     TodoList.unSelectTodoItem(item)
+                    m_adapter?.setFilteredTasks()
                 }
                 it.isActivated = newSelectedState
                 invalidateOptionsMenu()


### PR DESCRIPTION
We're kind of abusing setFilteredTasks, which updates the entire list. I remember reading about a way to notify of only the task in question that changed. But of course now I can't find that documentation, so let's stick with this for now :P