### PR TITLE
WIP - Help files, German translation

### DIFF
--- a/MYN.de.md
+++ b/MYN.de.md
@@ -1,0 +1,45 @@
+Manage Your Now
+===============
+
+Erstellen der Listen für MYN
+------------------------------
+
+In MYN gibt es drei Dringlichkeitszonen, die wir in Simpletask mit drei Listen in der folgenden Reihenfolge abbilden: 
+
+- Jetzt dringend -\> `@CriticalNow`
+- Jetzt erledigen -\> `@OpportunityNow`
+- Hinter dem Horizont -\> `@OverTheHorizon`
+
+Darüber hinaus definiert MYN eine Zone für wesentliche Ergebnisse (Significant Outcome - SOC), die über den anderen Zonen ganz oben auf der Liste angeordnet wird. Hierfür erstellen wir eine weitere Liste
+
+- Wesentliches Ergebnis -\> `@!SOC`
+
+Im `todo.txt`-Format werden Listen durch Aufgaben erzeugt, denen diese Listen zugeordnet sind. Dies hat den Nachteil, dass die Listen verschwinden, sobald die letzte Aufgabe mit dieser Liste aus der todo.txt-Datei gelöscht wird.
+
+Um Listen persistent zu machen, kann man in Simpletask Aufgaben mit dem Schalter `h:1` verstecken. Damit werden sie in der Aufgabenliste standardmäßig nicht angezeigt und ihre Tags und Listen bleiben dauerhaft verfügbar. 
+
+Für jede MYN-Liste, fügen wir also eine versteckte Aufgabe hinzu, z.B.:
+
+    @CriticalNow h:1
+
+Einrichten der Sortierung für MYN
+---------------------------------
+
+![](./images/MYN_sort.png) 
+
+`??? Screenshot aktualisiseren`
+
+Um Aufgaben in Simpletask bis zur Wiedervorlage auszublenden ("Defer-To-Do" und "Defer-To-Review" in MYN), kann man ihnen mit `t:yyyy-mm-dd` Anfangsdaten zuweisen. 
+
+Stellen Sie sicher, dass in den Einstellungen das `Defer by threshold date` markiert ist `??? Does not exist anymore`.
+
+Sie können Aufgaben, deren Anfangsdaten in der Zukunft liegt, entweder verbergen (siehe Registerkarte "Other" in den Filtereinstellungen) oder Sie können sie ans Ende der Liste sortieren (so sind sie noch sichtbar, aber aus dem Weg). Um dies zu erreichen, verwenden Sie die Sortierung `Anfangsdatum in der Zukunft`. 
+
+Ein weiteres wichtiges Konzept von MYN ist, neue Aufgaben am Anfgang der Liste und ältere weiter unten anzuzeigen. Hierfür sortiert man die Liste nach dem umgekehrten Anfangsdatum, siehe Beispiel in der Abbildung. Die weiteren Sortierkriterien haben nur geringe Bedeutung.
+
+Arbeiten mit der Liste
+----------------------
+
+Wenn Sie nun Ihre Aufgabenliste durchsehen und eine oder mehrere Aufgaben verschieben möchten, können Sie sie markieren und mit dem Button in der Symbolleiste ein neues Anfangsdatum setzen. 
+Einige in MYN / 1MTD häufig verwendete Auswahloptionen sind bereits voreingestellt, Sie können aber auch ein bestimmtes Datum mit dem Kalender wählen.
+Die Aufgabe wird nun entweder bis zum gewählten Datum ausgeblendet oder aber ans Ende der Liste und damit aus dem Blickfeld verschoben.

--- a/MYN.en.md
+++ b/MYN.en.md
@@ -1,0 +1,38 @@
+Manage Your Now
+===============
+
+Creating the contexts for MYN
+-----------------------------
+
+MYN defines 3 urgency zones, which we will map to lists in Simpletask in such a way that they sort correctly.
+
+-   Critical Now -\> `@CriticalNow`
+-   Opportunity Now -\> `@OpportunityNow`
+-   Over The Horizon -\> `@OverTheHorizon`
+
+Furthermore MYN defines a Significant Outcome (SOC) zone which needs to be at the top of you list. To achieve that, we map it to:
+
+-   Significant Outcome -\> `@!SOC`
+
+One disadvantage of the `todo.txt` format in combination with Simpletask is that if the file doesn't contain any items with a specific list, the list will not show up in Simpletask. To overcome this, Simpletask has a concept of hidden tasks. These tasked are marked with \`h:1' and by default will not show up in the task list. However any tags and lists defined on this task will be available.
+
+So in order to make the MYN lists persistent, add a hidden task for each one of the e.g.:
+
+    @CriticalNow h:1
+
+Configuring the sort for MYN
+----------------------------
+
+![](./images/MYN_sort.png) `???`
+
+`??? Update Screenshot`
+
+To defer tasks in Simpletask for Defer-To-Do or Defer-To-Review we use the threshold date functionallity. So make sure in settings the `Defer by threshold date` is checked. `??? does not exist anymore` You can then use threshold date `t:yyyy-mm-dd` as startdate in MYN/1MTD
+
+You can either hide future tasks (from the `Other` filter tab) or we can sort them to the end (so they are still visible but out of the way). To achieve that we use the `Threshold date in future` sort. The other main thing is to sort your list by reversed threshold date so that older tasks will be sorted lower on the list. Besides that it doesn't really matter how you sort after that, see picture the below for an example.
+
+Using the list
+--------------
+
+When you are reviewing the items on your list and you want to defer one or more tasks, you can select them and use the `defer` menu item in the overflow menu. `??? now in the icon-bar` There are some prefilled options which you would use often in MYN/1MTD or you can defer to a specific date. After defering the task it will move to the bottom of the listview if it has been defered into the future and out of your face.
+

--- a/addtask.de.md
+++ b/addtask.de.md
@@ -1,0 +1,13 @@
+Aufgaben hinzufügen oder bearbeiten
+--------
+
+In diesem Fenster können Sie neue Aufgaben hinzufügen oder bestehende bearbeiten. Es gibt zwei Optionen:
+
+* Zeilenumbruch: zeigt Aufgaben, die länger sind als die Fensterbreite in mehreren Zeilen an.
+* Vorausfüllen: übernimmt bei einem Zeilenwechsel Tags und Listen aus der vorhergehenden Zeile. So können sehr einfach mehrere Aufgaben mit den selben Kategorien und Listen hinzugefügt werden.
+
+Links
+-----
+- [Todo.txt Erweiterungen](./extensions.de.md)
+- [Inhalt der Hilfe](./index.de.md)
+

--- a/addtask.en.md
+++ b/addtask.en.md
@@ -1,0 +1,11 @@
+This screen allows you to add new tasks or updateCache existing ones. Every line in the text box will become one task. There are two checkboxes:
+
+* Word wrap: Should long lines be wrapped or run off to the right.
+* Pre-fill next: When checked, pressing next (or enter) on the keyboard will prefill the next line with the
+ tags and lists of the previous line. This makes it very easy quickly add multiple tasks with the same lists and tags.
+
+Links
+-----
+- [Todo.txt extensions](./extensions.en.md)
+- [Help index](./index.en.md)
+

--- a/extensions.de.md
+++ b/extensions.de.md
@@ -1,0 +1,15 @@
+Todo.txt Erweiterungen
+----------------------
+
+Simpletask unterstützt die folgenden Erweiterungen des todo.txt-Formates:
+
+- Fälligkeitsdatum mit `due:YYYY-MM-DD`
+- Anfangsdatum mit `t:YYYY-MM-DD`
+- Wiederholung mit `rec:\+?[0-9]+[dwmyb]` wie [hier](https://github.com/bram85/topydo/wiki/Recurrence) `??? Link funktioniert nicht` beschrieben, aber mit einer Ergänzung:
+    - Standardmäßig verwendet Simpletask das Fertigstellungsdatum für die Wiederholung, wie im Link beschrieben. Schreibt man jedoch vor die Zahl ein Plus (z. B. `rec:+2w`), wird das neue Datum vom ursprünglichen Anfangs- oder Fälligkeitsdatum aus berechnet.
+    - `rec:1b` bewirkt die Wiederholung nach 1 Werktag (Abkürzung für `b`usiness-day).
+    - Das Format wird durch einen regulären Ausdruck beschrieben. In Worten ist die Syntax `rec:` optional gefolgt von einem `+` dann einer Zahl und am Ende ein `d`ay, `w`eek, `m`onth oder `y`ear. Eine Aufgabe mit "rec: 12d" wird zum Beispiel nach 12 Tagen wiederholt.
+- Versteckte Aufgaben mit `h:1`
+
+  dienen dazu, Listen oder Tags vorzudefinieren und permanent zu machen. Die vordefinierten Tags und Listen bleiben auch dann noch erhalten, wenn alle anderen Aufgaben mit diesen Tags oder Listen aus der `todo.txt`-Datei entfernt wurden. Standardmäßig werden diese Aufgaben nicht angezeigt, bei Bedarf können sie jedoch in den Einstellungen eingeblendet werden.
+

--- a/extensions.en.md
+++ b/extensions.en.md
@@ -1,0 +1,12 @@
+Todo.txt Extensions
+-------------------
+
+Simpletask supports the following todo.txt extensions:
+
+-   Due date as `due:YYYY-MM-DD`
+-   Start/threshold date as `t:YYYY-MM-DD`
+-   Recurrence with `rec:\+?[0-9]+[dwmyb]` as described [here](https://github.com/bram85/topydo/wiki/Recurrence) `??? Link is broken` but with a twist.
+    - By default Simpletask will use the date of completion for recurring as described in the link. However if the rec includes a plus (e.g. `rec:+2w`), the date is determined from the original due or threshold date..
+    - `rec:1b` will recur after 1 weekday (mnemonic *b*usiness-day). 
+    - The format is described by a regular expression, so in words the syntax is `rec:` followed by an optional `+` then 1 or more numbers and then followed by one of `d`ay, `w`eek, `m`onth or `y`ear. For example `rec:12d` sets up a 12 day recurring task.
+- Hidden tasks with `h:1`, this allows dummy tasks with predefined lists and tags so that lists and tags will be available even if the last task with the tag/list is removed from `todo.txt`. These tasks will not be shown by default. You can temporarily display them from the Settings.

--- a/index.de.md
+++ b/index.de.md
@@ -1,0 +1,31 @@
+Simpletask
+==========
+
+See in [English](./index.en.md), Ver en [Español](./index.es.md)
+
+[Simpletask](https://github.com/mpcjanssen/simpletask-android) basiert auf dem brillanten [todo.txt](http://todotxt.com) von [Gina Trapani](http://ginatrapani.org/). Ziel der App ist es, ein Werkzeug für GTD zur Verfügung zu stellen und sich auf die hierfür wesentlichen Funktionen zu konzentrieren. Auch wenn Simpletask durch eine Reihe von Optionen sehr flexibel angepasst werden kann, sind die Voreinstellungen so gewählt, dass sie im Normalfall unverändert bleiben können. 
+
+[Simpletask](https://github.com/mpcjanssen/simpletask-android) kann als sehr einfache Aufgabenliste oder als komplexer Action Manager für GTD oder [Manage Your Now](./MYN.de.md) verwendet werden.
+
+Support
+-------
+
+Simpletask wird mit [weblate](https://hosted.weblate.org/engage/simpletask/) übersetzt. Folgen Sie dem Link, um zur Übersetzung beizutragen.
+
+Folgen Sie dem Chat auf [![Gitter](images/gitter.png)](https://gitter.im/mpcjanssen/simpletask-android) oder auf [#simpletask at Freenode](https://webchat.freenode.net/?channels=simpletask).
+
+Probleme oder Verbesserungsvorschläge für [Simpletask](https://github.com/mpcjanssen/simpletask-android/) können Sie im [Tracker](https://github.com/mpcjanssen/simpletask-android/issues) melden.
+
+Wenn Ihnen Simpletask gefällt, können Sie die Spenden-App kaufen (siehe Einstellungen) oder mir über [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mpc%2ejanssen%40gmail%2ecom&lc=NL&item_name=mpcjanssen%2enl&item_number=Simpletask&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted) ein paar Bier spendieren.
+
+Inhalt
+-------
+weitere Hilfekapitel im App-Menü oder unter folgenden Links:
+
+- [Benutzeroberfläche](./ui.de.md)
+- [Änderungsprotokoll](./changelog.en.md)
+- [Todo.txt Erweiterungen](./extensions.de.md)
+- [Listen und Tags](./listsandtags.de.md) Warum verwendet Simpletask die Begriffe "Liste" und "Tag" statt "Kontext" und "Projekt" aus todo.txt?
+- [Definierte Intents](./intents.de.md) Android Intents, die für die Automatisierung von Simpletask verwendet werden können.
+- [1MTD/MYN mit Simpletask](./MYN.de.md)
+- [Skripten mit Lua](./script.de.md)

--- a/index.en.md
+++ b/index.en.md
@@ -1,0 +1,39 @@
+Simpletask
+==========
+Ver en [Español](./index.es.md), auf [Deutsch](./index.de.md) 
+
+[Simpletask](https://github.com/mpcjanssen/simpletask-android) is based on the brilliant [todo.txt](http://todotxt.com) by [Gina Trapani](http://ginatrapani.org/). The goal of the application is to provide a tool to do GTD without providing an overwhelming amount of options. Even though Simpletask can be customised by a fairly large amount of settings, the defaults should be sane and require no change.
+
+[Simpletask](https://github.com/mpcjanssen/simpletask-android) can be used as a very simple todo list manager or as a more complex action manager for GTD or [Manage Your Now](./MYN.en.md).
+
+Extensions
+----------
+
+Simpletask supports the following todo.txt extensions:
+
+-   Due date as `due:YYYY-MM-DD`
+-   Start/threshold date as `t:YYYY-MM-DD`
+-   Recurrence with `rec:\+?[0-9]+[dwmyb]` as described [here](https://github.com/bram85/topydo/wiki/Recurrence) but with a twist.
+    - By default Simpletask will use the date of completion for recurring as described in the link. However if the rec includes a plus (e.g. `rec:+2w`), the date is determined from the original due or threshold date..
+    - `rec:1b` will recur after 1 weekday (mnemonic *b*usiness-day). 
+    - The format is described by a regular expression, so in words the syntax is `rec:` followed by an optional `+` then 1 or more numbers and then followed by one of `d`ay, `w`eek, `m`onth or `y`ear. For example `rec:12d` sets up a 12 day recurring task.
+- Hidden tasks with `h:1`, this allows dummy tasks with predefined lists and tags so that lists and tags will be available even if the last task with the tag/list is removed from `todo.txt`. These tasks will not be shown by default. You can temporarily display them from the Settings.
+
+Support
+-------
+
+Simpletask is translated using [weblate](https://hosted.weblate.org/engage/simpletask/). Follow the link to contribute.
+
+Join the chat at [![Gitter](images/gitter.png)](https://gitter.im/mpcjanssen/simpletask-android) or at [#simpletask at Freenode](https://webchat.freenode.net/?channels=simpletask)
+
+If you want to log an issue or feature request for [Simpletask](https://github.com/mpcjanssen/simpletask-android/) you can go to [the tracker](https://github.com/mpcjanssen/simpletask-android/issues). If you find Simpletask useful, you can buy the donate app (see Settings) or donate via [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mpc%2ejanssen%40gmail%2ecom&lc=NL&item_name=mpcjanssen%2enl&item_number=Simpletask&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted) me some beers.
+
+Check the menu for more help sections or click below.
+
+- [User Interface](./ui.en.md) Help on the user interface.
+- [Changelog](./changelog.en.md)
+- [Lists and Tags](./listsandtags.en.md) Why does Simpletask use lists and Tags instead of the Contexts and Projects from todo.txt?
+- [Defined intents](./intents.en.md) Intents that can be used for automating Simpletask
+- [Using Simpletask for 1MTD/MYN](./MYN.en.md)
+- [Using Lua](./script.en.md)
+

--- a/intents.de.md
+++ b/intents.de.md
@@ -1,0 +1,127 @@
+Intents
+=======
+
+Simpletask unterstützt einige Android-Intents, die von anderen Apps (z. B. Tasker) verwendet werden können, um Aufgaben zu erstellen oder Listen anzuzeigen.
+
+Neue Aufgabe im Hintergrund
+---------------------------
+
+Um eine Aufgabe im Hintergrund zu erstellen, also ohne Simpletask anzuzeigen, kann dieser Intent verwendet werden:
+
+-   Intent action: `nl.mpcjanssen.simpletask.BACKGROUND_TASK`
+-   Intent string extra: `task`
+
+Der Intent übergibt zusätzlich die Zeichenkette `task`, welche die zu erstellende Aufgabe enthält.
+
+Zum Beispiel kann mit Tasker eine neue Aufgabe erstellt werden, indem man folgende Aktion definiert: 
+
+-   Action: `nl.mpcjanssen.simpletask.BACKGROUND_TASK`
+-   Cat: Default
+-   Mime Type: text/\*
+-   Extra: task: `<Aufgabentext mit möglichen Variablen> +tasker`
+-   Target: Activity
+
+Ich füge das `+tasker`-Tag hinzu, um später die von Tasker erstellten Aufgaben schneller filtern zu können.
+
+Öffnen mit aktiviertem Filter
+-----------------------------
+
+Um Simpletask mit einem bestimmten Filter zu öffnen, kann folgender Intent genutzt werden:
+
+-   Intent action: `nl.mpcjanssen.simpletask.START_WITH_FILTER`
+-   Intent extras: Die folgenden Extras können als Teil des Intents hinzugefügt werden. Beachten Sie, dass die Namen derzeit noch die ursprüngliche Namensgebung, also Contexts und Projects widerspiegeln.
+
+<table>
+<colgroup>
+<col width="19%" />
+<col width="12%" />
+<col width="67%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th align="left">Name</th>
+<th align="left">Typ</th>
+<th align="left">Syntax</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">CONTEXTS</td>
+<td align="left">String</td>
+<td align="left">filtert nach einer Liste von Listen, Trennzeichen 'n' oder ','</td>
+</tr>
+<tr class="even">
+<td align="left">PROJECTS</td>
+<td align="left">String</td>
+<td align="left">filtert nach einer Liste von Tags, Trennzeichen 'n' oder ','</td>
+</tr>
+<tr class="odd">
+<td align="left">PRIORITIES</td>
+<td align="left">String</td>
+<td align="left">filtert nach einer Liste von Prioritäten, Trennzeichen 'n' oder ','</td>
+</tr>
+<tr class="even">
+<td align="left">CONTEXTSnot</td>
+<td align="left">Boolean</td>
+<td align="left">"true" invertiert den Filter für Listen</td>
+</tr>
+<tr class="odd">
+<td align="left">PROJECTSnot</td>
+<td align="left">Boolean</td>
+<td align="left">"true" invertiert den Filter für Tags</td>
+</tr>
+<tr class="even">
+<td align="left">PRIORITIESnot</td>
+<td align="left">Boolean</td>
+<td align="left">"true" invertiert den Filter für Prioritäten</td>
+</tr>
+<tr class="odd">
+<td align="left">HIDECOMPLETED</td>
+<td align="left">Boolean</td>
+<td align="left">"true" blendet erledigte Aufgaben aus</td>
+</tr>
+<tr class="even">
+<td align="left">HIDEFUTURE</td>
+<td align="left">Boolean</td>
+<td align="left">"true" blendet Aufgaben mit Anfangsdatum in der Zukunft aus</td>
+</tr>
+<tr class="odd">
+<td align="left">SORTS</td>
+<td align="left">String</td>
+<td align="left">aktiviert eine Sortierung (siehe unten)</td>
+</tr>
+</tbody>
+</table>
+
+### Sortierung
+
+SORTS enthält eine mit Kommas oder '' getrennte Liste von Sortierschlüsseln und deren Richtung mit einem `!` dazwischen, also `<Richtung>!<Sortierschlüssel>`.
+
+#### Richtung
+
+- `+`: Aufsteigend
+- `-`: Absteigend
+
+#### Sortierschlüssel
+
+Siehe Liste in [arrays.xml](https://github.com/mpcjanssen/simpletask-android/blob/master/src/main/res/values/donottranslate.xml#L42-51) `??? Link funktioniert nicht`
+
+#### Beispiel
+
+- Die Sortierung `+!completed,+!alphabetical` sortiert abgeschlossene Aufgaben ans Ende und dann alphabetisch.
+- Die Sortierung `+!completed,-!alphabetical` sortiert abgeschlossene Aufgaben ans Ende und dann alphabetisch in umgekehrter Richtung.
+
+### Beispiel für Tasker
+
+-   Action: `nl.mpcjanssen.simpletask.START_WITH_FILTER`
+-   Cat: `Default`
+-   Mime Type:
+-   Extra: `CONTEXTS:Office,Online`
+-   Extra: `SORTS:+!completed,+!alphabetical`
+-   Target: `Activity`
+
+Aufgrund von Einschränkungen in Tasker können nur bis zu zwei Extras hinzugefügt werden. Stattdessen können Sie den am-shell-Befehl verwenden, also beispielsweise:
+
+    am start -a nl.mpcjanssen.simpletask.START_WITH_FILTER -e SORTS +!completed,+!alphabetical -e PROJECTS project1,project2 -e CONTEXTS @errands,@computer --ez CONTEXTSnot true -c android.intent.category.DEFAULT -S
+
+Das `-S` am Ende wird sicherstellen, dass die App korrekt neu gestartet wird, wenn sie bereits sichtbar ist. Dagegen scheint das `-S` mit Tasker nicht zu funktionieren.

--- a/intents.en.md
+++ b/intents.en.md
@@ -1,0 +1,128 @@
+Intents
+=======
+
+Simpletask supports a couple of intents which can be used by other applications (e.g. tasker) to create tasks or display lists.
+
+Create task in background
+-------------------------
+
+To create a task in the background, so without showing simpletask, you can use the intent:
+
+-   Intent action: `nl.mpcjanssen.simpletask.BACKGROUND_TASK`
+-   Intent string extra: `task`
+
+the intent will have one extra string `task` which contains the task to be added.
+
+For example to create a task from tasker use the following action:
+
+-   Action: `nl.mpcjanssen.simpletask.BACKGROUND_TASK`
+-   Cat: Default
+-   Mime Type: text/\*
+-   Extra: task: `<Task text with possible variables here> +tasker`
+-   Target: Activity
+
+I like to add the `+tasker` tag to be able to quickly filter tasks that were created by tasker.
+
+Open with specific filter
+-------------------------
+
+To open Simpletask with a specific filter you can use the intent:
+
+-   Intent action: `nl.mpcjanssen.simpletask.START_WITH_FILTER`
+-   Intent extras: The following extras can be added as part of the intent. Note that currently the names still reflect the original naming of lists/tags.
+
+<table>
+<colgroup>
+<col width="19%" />
+<col width="12%" />
+<col width="67%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th align="left">Name</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">CONTEXTS</td>
+<td align="left">String</td>
+<td align="left">list of lists in filter separated by 'n' or ','</td>
+</tr>
+<tr class="even">
+<td align="left">PROJECTS</td>
+<td align="left">String</td>
+<td align="left">list of tags in filter separated by 'n' or ','</td>
+</tr>
+<tr class="odd">
+<td align="left">PRIORITIES</td>
+<td align="left">String</td>
+<td align="left">list of priorities in filter separated by 'n' or ',</td>
+</tr>
+<tr class="even">
+<td align="left">CONTEXTSnot</td>
+<td align="left">Boolean</td>
+<td align="left">true to invert the lists filter</td>
+</tr>
+<tr class="odd">
+<td align="left">PROJECTSnot</td>
+<td align="left">Boolean</td>
+<td align="left">true to invert the tags filter</td>
+</tr>
+<tr class="even">
+<td align="left">PRIORITIESnot</td>
+<td align="left">Boolean</td>
+<td align="left">true to invert the priorities filter</td>
+</tr>
+<tr class="odd">
+<td align="left">HIDECOMPLETED</td>
+<td align="left">Boolean</td>
+<td align="left">true to hide completed tasks</td>
+</tr>
+<tr class="even">
+<td align="left">HIDEFUTURE</td>
+<td align="left">Boolean</td>
+<td align="left">true to hide tasks with a threshold date</td>
+</tr>
+<tr class="odd">
+<td align="left">SORTS</td>
+<td align="left">String</td>
+<td align="left">active sort (see below)</td>
+</tr>
+</tbody>
+</table>
+
+### Sorts extra
+
+SORTS contains a comma or '' separated list of sort keys and their direction with a `!` in between. Giving `<direction>!<sort key>`.
+
+#### Direction
+
+-   `+` : Ascending
+-   `-` : Descending
+
+#### Sort keys
+
+See list in [arrays.xml](https://github.com/mpcjanssen/simpletask-android/blob/master/src/main/res/values/donottranslate.xml#L42-51) `??? Link is broken`
+
+#### Example
+
+-   The sort `+!completed,+!alphabetical` sorts completed tasks last and then sorts alphabetical.
+-   The sort `+!completed,-!alphabetical` sorts completed tasks last and then sorts reversed alphabetical.
+
+### Tasker example
+
+-   Action: `nl.mpcjanssen.simpletask.START_WITH_FILTER`
+-   Cat: `Default`
+-   Mime Type:
+-   Extra: `CONTEXTS:Office,Online`
+-   Extra: `SORTS:+!completed,+!alphabetical`
+-   Target: `Activity`
+
+Due to limitations in Tasker you can only add 2 extras. So instead you can use the am shell command. For example:
+
+    am start -a nl.mpcjanssen.simpletask.START_WITH_FILTER -e SORTS +!completed,+!alphabetical -e PROJECTS project1,project2 -e CONTEXTS @errands,@computer --ez CONTEXTSnot true -c android.intent.category.DEFAULT -S
+
+The `-S` at the end will ensure the app is properly restarted if it's already visible. However with tasker the `-S` seems not to work. So there try it without.
+

--- a/listsandtags.de.md
+++ b/listsandtags.de.md
@@ -1,0 +1,19 @@
+# Listen und Tags
+
+Warum verwendet Simpletask Listen und Tags?
+
+## Kontexte vs Listen
+
+Statt der Kontexte und Projekte in todo.txt wird in Simpletask `@irgendwas` als Liste und `+irgendwas` als Tag bezeichnet. Wie kam es zu dieser Entscheidung? Dreht sich bei GTD nicht alles um Kontexte?
+
+Na ja, eigentlich nicht. Auch wenn dies im ursprünglichen Buch "Getting Things Done" deutlicher hätte formuliert werden können, ist in GTD das wichtigste Organisationsmittel die Liste. Einige Listen enthalten die nächsten Aktionen für einen bestimmten Kontext (z.B. `@computer`) andere jedoch nicht (z. B. `Projekte` oder `Warten auf`).
+
+Obwohl viele der Listen in GTD nächste Aktionen für einen bestimmten Kontext enthalten, ist der Kontext nicht das wichtigste Organisationsmittel (z. B. ist `Warten auf` kein Kontext).
+
+## Projekte vs Tags
+
+Projekte werden in Simpletask Tags genannt, weil Tags ein allgemeineres Konzept ist. Ein Tag kann alles sein, von einem Projekt bis hin zum Namen einer Person. Dies ermöglicht die Verwendung von Aufgaben wie:
+
+`+DavidAllen @anrufen bezüglich +GTD`
+
+In diesem Fall sind keine der Tags Projekte.

--- a/listsandtags.en.md
+++ b/listsandtags.en.md
@@ -1,0 +1,27 @@
+# Lists and Tags
+
+Why does Simpletask use Lists and Tags?
+
+## Contexts vs Lists
+
+Instead of the contexts and projects in todo.txt, simpletask calls `@something`
+a list and `+something` a tag. Why was this chosen, isn't GTD all about
+contexts?
+
+Well no actually. Even though this is not as clearly articulated in the original
+Getting Things Done book as it could be, in GTD the main organizing element is
+the list. Some of these lists contain next actions for a certain context (e.g.
+@computer) but some don't (e.g. Projects or Waiting For).
+
+So even though a lot of the lists in GTD will contain next actions for
+a certain context, this doesn't imply that context is the main organizing
+element (e.g. Waiting For is not a context)
+
+## Projects vs Tags
+
+Projects are renamed to tags because tags is a more general concept. A tag can
+be anything from a project to a person's name. This allows using tasks like:
+
+`@Call +DavidAllen regarding +GTD`
+
+In this case neither of the tags are projects.


### PR DESCRIPTION
@mpcjanssen Finally I finished the german translation of the help-files. You were right, it was quite some work :-)

The following files I didn't translate, because they are not linked to the help index and I am not sure, if they are still in use: 
**defertasks, design, gradle** and **versions**. The **changelog** I didn't translate neither, doesn't make sense.

I wrote some comments directly into the files and marked them with **???** so they can easily be searched for.

Comments or questions to some help files:
**addtasks**: headers without text, is there missing something? I deleted them for now or did you plan to add something? 
**extensions**: I suggest to separate the section on the todo.txt-extensions from addtasks and index and put it into a new file. This way the text is only kept in one place. The link to topydo is broken.
**index**: through the separation of the extensions, it concentrates more on the summary, support-links and Help-Index.
**intends**: there is no word wrap in Android-Studio, maybe because of the chart?
**MYN**: Should I update screenshot,? The setting "Defer by threshold date" does not exist anymore, or am I missing something?
**Script**: small layout-adaptions on the headlines
**UI**, FIrst sentence: Do you still plan to add something? I could write it down, if you like. Although most features can be learned by simply using the app, there are some, which are not visible on first sight: e.g. long press on task or invert filter in quick filter drawer. Maybe it would be good to write something about those, especially for new users.