### PR TITLE
fix NPE on startup

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
@@ -15,8 +15,6 @@ import java.nio.charset.Charset
 import java.util.*
 
 object Config : Preferences(TodoApplication.app), SharedPreferences.OnSharedPreferenceChangeListener {
-    val interpreter = LuaInterpreter
-
     val TAG = "LuaConfig"
 
     init {
@@ -136,7 +134,7 @@ object Config : Preferences(TodoApplication.app), SharedPreferences.OnSharedPref
 
     private val _activeTheme by StringPreference(R.string.theme_pref_key, "light_darkactionbar")
     private val activeThemeString: String
-        get() = interpreter.configTheme() ?: _activeTheme
+        get() = LuaInterpreter.configTheme() ?: _activeTheme
 
     // Only used in Dropbox build
     @Suppress("unused")
@@ -152,7 +150,7 @@ object Config : Preferences(TodoApplication.app), SharedPreferences.OnSharedPref
 
     val tasklistTextSize: Float?
         get() {
-            val luaValue = interpreter.tasklistTextSize()
+            val luaValue = LuaInterpreter.tasklistTextSize()
             if (luaValue != null) {
                 return luaValue
             }


### PR DESCRIPTION
Analysis below copied from gitter in case anyone's looking at this later.

----

Debugging shows that LuaInterpreter is initialized first and the crash happens when it calls Config, which tries to get a reference to the still-mid-init LuaInterpreter. Precisely why that line causes a crash (ie, what's null) is unclear to me; "Step in" jumps directly to a finally block in the Android internals (ActivityThread.java), with no clear indication of what's wrong.

My best guess for how this is related is, Kotlin implements delegates like this (copied from https://kotlinlang.org/docs/reference/delegated-properties.html):

```
class C {
    var prop: Type by MyDelegate()
}

// this code is generated by the compiler instead:
class C {
    private val prop$delegate = MyDelegate()
    var prop: Type
        get() = prop$delegate.getValue(this, this::prop)
        set(value: Type) = prop$delegate.setValue(this, this::prop, value)
}
```

Before, we got the config values directly from the shared preferences. Now, it includes a call which passes a reference to Config (the this above). But Config hasn't been initialized yet.

The weird part is that ^that logical analysis is a different conclusion from the debugging above (that it crashes at the val interpreter = LuaInterpreter line). `¯\_(ツ)_/¯`