### PR TITLE
Sync TodoList on adding tasks

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
@@ -50,6 +50,8 @@ class AddTask : ThemedActionBarActivity() {
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS)
         super.onCreate(savedInstanceState)
 
+        TodoApplication.app.loadTodoList("before adding tasks")
+
         val intentFilter = IntentFilter()
         intentFilter.addAction(Constants.BROADCAST_UPDATE_UI)
         intentFilter.addAction(Constants.BROADCAST_SYNC_START)


### PR DESCRIPTION
When using the add task widget, nothing syncs before trying to add, leading to easily avoidable conflicts.