### PR TITLE
Allow text of tasks to be updated.

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
@@ -89,7 +89,9 @@ class AddTask : ThemedActionBarActivity() {
 
         setTitle(R.string.addtask)
 
-        m_backup.addAll(TodoList.pendingEdits)
+        TodoList.pendingEdits.forEach {
+            m_backup.add(TodoList.todoItems.get(it.toInt()))
+        }
         val preFillString = if (m_backup.isNotEmpty()) {
             setTitle(R.string.updatetask)
             join(m_backup.map(Task::inFileFormat), "\n")
@@ -274,11 +276,18 @@ class AddTask : ThemedActionBarActivity() {
         // Update the TodoList with changes
         // Create new tasks
         val enteredTasks = getTasks().dropLastWhile { it.text.isEmpty() }
+        if (enteredTasks.size < TodoList.pendingEdits.size) {
+            log.info(TAG, "Task size mismatch.")
+            showToastLong(this, "Task count differs. Aborting edits.")
+            finishEdit()
+            return
+        }
         log.info(TAG, "Saving ${enteredTasks.size} tasks, updating ${m_backup.size} tasks" )
-        for (task in enteredTasks) {
+        for ((i, task) in enteredTasks.withIndex()) {
             if (m_backup.size > 0) {
+                val taskIndex = TodoList.pendingEdits.get(i).toInt()
+                TodoList.todoItems.get(taskIndex).update(task.text)
                 // Don't modify create date for updated tasks
-                m_backup[0].update(task.text)
                 m_backup.removeAt(0)
             } else {
                 val t: Task

--- a/app/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
@@ -58,7 +58,7 @@ object TodoList {
     private var mTags: ArrayList<String>? = null
     val todoItems = CopyOnWriteArrayList<Task>()
     val selectedItems = CopyOnWriteArraySet<Task>()
-    val pendingEdits = LinkedHashSet<Task>()
+    val pendingEdits = ArrayList<Integer>()
     internal val TAG = TodoList::class.java.simpleName
 
     fun hasPendingAction(): Boolean {
@@ -96,7 +96,9 @@ object TodoList {
         queue("Remove") {
             todoItems.removeAll(tasks)
             selectedItems.removeAll(tasks)
-            pendingEdits.removeAll(tasks)
+            tasks.forEach {
+                pendingEdits.remove(Integer(todoItems.indexOf(it)))
+            }
         }
     }
 
@@ -355,7 +357,12 @@ object TodoList {
 
     fun editTasks(from: Activity, tasks: List<Task>, prefill: String) {
         queue("Edit tasks") {
-            pendingEdits.addAll(tasks)
+            for (task in tasks) {
+                val i = TodoList.todoItems.indexOf(task)
+                if (i >= 0) {
+                    pendingEdits.add(Integer(i))
+                }
+            }
             startAddTaskActivity(from, prefill)
         }
     }


### PR DESCRIPTION
I noticed a new bug with the latest builds. Perhaps it has already been fixed. If not, this illustrates it and offers a possible fix.

To reproduce:
  Create one or more tasks. No need to add lists or tags.
  Select the task(s).
  Click the pencil icon to edit the task(s)
  Change the text of one or more tasks.
  Click the save button.
  The text of the tasks that were edited are not updated with the new values.

This PR tries to make minimal changes to the code to highlight and fix the problem. The changes may not be the desired method of fixing this bug. I will not be offended at all if this PR is rejected.

Notes:

While editing, tasks are listed in the order they are selected, not the currently displayed sort order.

While editing, any task can be deleted by removing all text on the line and leaving the line blank. This is true for all tasks except for the last listed task.
 
When saving, if the number of edited tasks does not equal or exceed the number of selected tasks, all edits will be ignored. This is a safeguard to prevent updating tasks incorrectly.

A simple rule when editing tasks is: Tasks must not change lines.