### PR TITLE
Create tags and lists while in dialog.

### DIFF
--- a/app/src/main/res/layout/single_task_tag_dialog.xml
+++ b/app/src/main/res/layout/single_task_tag_dialog.xml
@@ -6,13 +6,36 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
-    <EditText
+
+    <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/editText"
-        android:layout_gravity="center_horizontal"
-        android:singleLine="true"
-        />
+        android:layout_height="match_parent"
+        >
+        <ImageButton
+            android:id="@+id/item_select"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            android:onClick="onClickAddItem"
+            android:paddingLeft="2dp"
+            android:paddingRight="2dp"
+            android:paddingTop="0dp"
+            android:background="?attr/colorPrimary"
+            android:src="@drawable/ic_add_white_24dp"
+            />
+        <EditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/editText"
+            android:layout_gravity="center_horizontal"
+            android:singleLine="true"
+            />
+    </LinearLayout>
+
     <ListView
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/update_items_dialog.xml
+++ b/app/src/main/res/layout/update_items_dialog.xml
@@ -6,12 +6,36 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
-    <EditText
+
+    <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/new_item_text"
-        android:layout_gravity="center_horizontal"
-        android:maxLines="1"/>
+        android:layout_height="match_parent"
+        >
+        <ImageButton
+            android:id="@+id/new_item_add_button"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            android:onClick="onClickAddItem"
+            android:paddingLeft="2dp"
+            android:paddingRight="2dp"
+            android:paddingTop="0dp"
+            android:background="?attr/colorPrimary"
+            android:src="@drawable/ic_add_white_24dp"
+            />
+        <EditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/new_item_text"
+            android:layout_gravity="center_horizontal"
+            android:maxLines="1"
+            />
+    </LinearLayout>
+
     <android.support.v7.widget.RecyclerView
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -3,4 +3,7 @@
 <resources>
     <item name="invalid_project" type="id">Invalid tag</item>
     <item name="invalid_context" type="id">Invalid list</item>
+    <item name="dialog_type_key" type="id"/>
+    <item name="pick_lists_dialog" type="id"/>
+    <item name="pick_tags_dialog" type="id"/>
 </resources>


### PR DESCRIPTION
This PR allows adding multiple tags/lists without having to exit the create/edit dialog. 

I was pretty sure that I saw this somewhere in the list of issues, but I can't find a reference to it anymore.

The button that I added for adding tasks/list is not very pretty. I didn't know how you wanted to trigger the 'add' action, so I just threw a button on there. I'll be happy to adjust/polish it, if needed.

There are several different ways this fix could have been accomplished. I tried to disturb the code as little as possible. 

If this is no longer an issue worth including or the implementation is undesirable, just let me know so I can close this PR.


You probably already know about these, but I thought I'd mention them:

When editing a tag/list from the main screen, the items are grouped by 'all', then 'partial', then 'none' and items are sorted alphabetically within those groups. 
When editing a tag/list from the edit task screen, the sort order is strictly alphabetical.

When editing a tag/list from the main screen, the checkboxes are on the left side of the dialog.
When editing a tag/list from the edit task screen, the checkboxes are on the right side of the dialog.
