### PR TITLE
fix duplicate space when adding task with prefill

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -827,7 +827,7 @@ class Simpletask : ThemedNoActionBarActivity() {
     private fun startAddTaskActivity() {
         log.info(TAG, "Starting addTask activity")
 
-        TodoList.editTasks(this, TodoList.selectedTasks, " ${mainFilter.prefill}")
+        TodoList.editTasks(this, TodoList.selectedTasks, mainFilter.prefill)
     }
 
     private fun startPreferencesActivity() {


### PR DESCRIPTION
`ActiveFilter.prefill` already prefixes a space, so we don't need to do it again here.