### PR TITLE
index tokens by 1 to follow lua convention

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/LuaInterpreter.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/LuaInterpreter.kt
@@ -239,7 +239,7 @@ end
             val tokenTable =  LuaTable.tableOf()
             tokenTable.set("type", LuaValue.valueOf(tok.type))
             tokenTable.set("text", LuaValue.valueOf(tok.text))
-            tokensTable.set(idx, tokenTable)
+            tokensTable.set(idx+1, tokenTable)
         }
         fieldTable.set("tokens", tokensTable)
         fieldTable.set("due", dateStringToLuaLong(t.dueDate))


### PR DESCRIPTION
When indexing by zero, some standard library features like `ipairs(table)` will skip the first element in the table-as-an-array.

This will break people's scripts if they use this, so that's a pain, but so is not being able to properly iterate through the tokens.