### PR TITLE
share visible text if using lua onDisplay

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -211,8 +211,9 @@ class Simpletask : ThemedNoActionBarActivity() {
 
     private fun selectedTasksAsString(): String {
         val result = ArrayList<String>()
-        TodoList.selectedTasks.forEach {
-            result.add(it.inFileFormat())
+        TodoList.selectedTasks.forEach { task ->
+            val luaTxt = LuaInterpreter.onDisplayCallback(mainFilter.options.luaModule, task)
+            result.add(luaTxt ?: task.inFileFormat())
         }
         return join(result, "\n")
     }
@@ -793,12 +794,14 @@ class Simpletask : ThemedNoActionBarActivity() {
         var calendarDescription = ""
         if (checkedTasks.size == 1) {
             // Set the task as title
-            calendarTitle = checkedTasks[0].text
+            val task = checkedTasks[0]
+            val luaTxt = LuaInterpreter.onDisplayCallback(mainFilter.options.luaModule, task)
+            calendarTitle = luaTxt ?: task.text
         } else {
             // Set the tasks as description
             calendarDescription = selectedTasksAsString()
-
         }
+
         intent = Intent(Intent.ACTION_EDIT).apply {
             setType(Constants.ANDROID_EVENT)
             putExtra(Events.TITLE, calendarTitle)


### PR DESCRIPTION
If the lua onDisplay callback is defined, share that text (ie, as
displayed in the app) instead of the full text as in the config file.

Same for creating calendar appointments.

---

Ideally, we'd share the task text as it is displayed (see #236). However, there is currently no concept of that in the code. Adding the functionality without refactoring to create the concept in the code would be a *ton* of duplicate code.

I don't want to create that much tech debt, but at the same time, I don't have enough time on my hands to do the needed refactoring. So, this is a compromise: Do the intuitive thing iff the lua onDisplay callback is defined (since an abstraction of that already exists, it's only a few lines to implement).