### PR TITLE
Add option to show null dates first, rather than last.

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
@@ -80,7 +80,7 @@ data class AppWidgetRemoteViewsFactory(val intent: Intent) : RemoteViewsService.
         val sorts = currentFilter.getSort(Config.defaultSorts)
 
         val newVisibleTasks = ArrayList<Task>()
-        newVisibleTasks.addAll(TodoList.getSortedTasks(currentFilter, sorts, Config.sortCaseSensitive))
+        newVisibleTasks.addAll(TodoList.getSortedTasks(currentFilter, sorts, Config.sortCaseSensitive, Config.isNullDatesFirst))
         log.debug(TAG, "Widget $widgetId: setFilteredTasks returned ${newVisibleTasks.size} tasks")
         visibleTasks = newVisibleTasks
     }

--- a/app/src/main/java/nl/mpcjanssen/simpletask/MultiComparator.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/MultiComparator.kt
@@ -5,7 +5,7 @@ import nl.mpcjanssen.simpletask.task.TToken
 import nl.mpcjanssen.simpletask.task.Task
 import java.util.*
 
-class MultiComparator(sorts: ArrayList<String>, today: String, caseSensitve: Boolean, createAsBackup: Boolean) {
+class MultiComparator(sorts: ArrayList<String>, today: String, caseSensitve: Boolean, createAsBackup: Boolean, showNullDatesFirst: Boolean) {
     var comparator : Comparator<Task>? = null
 
     var fileOrder = true
@@ -28,7 +28,7 @@ class MultiComparator(sorts: ArrayList<String>, today: String, caseSensitve: Boo
                 }
             }
             var comp: (Task) -> Comparable<*>
-            val last_date = "9999-99-99"
+            val nullDateVal = if (showNullDatesFirst) "0000-00-00" else "9999-99-99";
             when (sortType) {
                 "file_order" -> {
                     fileOrder = !reverse
@@ -50,14 +50,14 @@ class MultiComparator(sorts: ArrayList<String>, today: String, caseSensitve: Boo
                     }
                 }
                 "completed" -> comp = { it.isCompleted() }
-                "by_creation_date" -> comp = { it.createDate ?: last_date }
+                "by_creation_date" -> comp = { it.createDate ?: nullDateVal }
                 "in_future" -> comp = { it.inFuture(today) }
-                "by_due_date" -> comp = { it.dueDate ?: last_date }
+                "by_due_date" -> comp = { it.dueDate ?: nullDateVal }
                 "by_threshold_date" -> comp = {
-                    val fallback = if (createAsBackup) it.createDate ?: last_date else last_date
+                    val fallback = if (createAsBackup) it.createDate ?: nullDateVal else nullDateVal
                     it.thresholdDate ?: fallback
                 }
-                "by_completion_date" -> comp = { it.completionDate ?: last_date }
+                "by_completion_date" -> comp = { it.completionDate ?: nullDateVal }
                 else -> {
                     log.warn("MultiComparator", "Unknown sort: " + sort)
                     continue@label

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -1457,7 +1457,7 @@ class Simpletask : ThemedNoActionBarActivity() {
                 val visibleTasks: Sequence<Task>
                 log.info(TAG, "setFilteredTasks called: " + TodoList)
                 val sorts = mainFilter.getSort(Config.defaultSorts)
-                visibleTasks = TodoList.getSortedTasks(mainFilter, sorts, Config.sortCaseSensitive)
+                visibleTasks = TodoList.getSortedTasks(mainFilter, sorts, Config.sortCaseSensitive, Config.isNullDatesFirst)
                 val newVisibleLines = ArrayList<VisibleLine>()
 
                 newVisibleLines.addAll(addHeaderLines(visibleTasks, mainFilter, getString(R.string.no_header)))

--- a/app/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
@@ -208,8 +208,8 @@ object TodoList {
         }
     }
 
-    fun getSortedTasks(filter: ActiveFilter, sorts: ArrayList<String>, caseSensitive: Boolean): Sequence<Task> {
-        val comp = MultiComparator(sorts, TodoApplication.app.today, caseSensitive, filter.createIsThreshold)
+    fun getSortedTasks(filter: ActiveFilter, sorts: ArrayList<String>, caseSensitive: Boolean, showNullDatesFirst: Boolean): Sequence<Task> {
+        val comp = MultiComparator(sorts, TodoApplication.app.today, caseSensitive, filter.createIsThreshold, showNullDatesFirst)
         val itemsToSort = if (comp.fileOrder) {
             todoItems
         } else {

--- a/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
@@ -232,6 +232,8 @@ object Config : Preferences(TodoApplication.app), SharedPreferences.OnSharedPref
 
     val hasPrependDate by BooleanPreference(R.string.prepend_date_pref_key, true)
 
+    val isNullDatesFirst by BooleanPreference(R.string.show_null_dates_first_pref_key, false)
+
     val hasKeepSelection by BooleanPreference(R.string.keep_selection, false)
 
     val hasKeepPrio by BooleanPreference(R.string.keep_prio, true)

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -121,6 +121,7 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="auto_archive_pref_key"          translatable="false">todotxtautoarchive</string>
     <string name="default_sort_pref_key"          translatable="false">default_sort</string>
     <string name="prepend_date_pref_key"          translatable="false">todotxtprependdate</string>
+    <string name="show_null_dates_first_pref_key" translatable="false">shownulldatesfirstpref</string>
     <string name="line_breaks_pref_key"           translatable="false">linebreakspref</string>
     <string name="manual_sync_pref_key"           translatable="false">workofflinepref</string>
     <string name="resume_sync_pref_key"           translatable="false">resumesyncpref</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,8 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="keep_prio_summary">Todo.txt removes priority on completion</string>
     <string name="prepend_date_pref_title">Datestamp new tasks</string>
     <string name="prepend_date_pref_summary">Automatically add creation date</string>
+    <string name="show_null_dates_first_pref_title">Empty dates first</string>
+    <string name="show_null_dates_first_pref_summary">Display items with no dates first</string>
     <string name="line_breaks_pref_title">Windows-friendly line breaks</string>
     <string name="line_breaks_pref_summary">Use Windows-friendly line breaks</string>
     <string name="recur_from_original_date_pref_title">Recur task using original dates</string>

--- a/app/src/main/res/xml/other_preferences.xml
+++ b/app/src/main/res/xml/other_preferences.xml
@@ -46,6 +46,13 @@
         android:title="@string/prepend_date_pref_title"
         />
     <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/show_null_dates_first_pref_key"
+        android:summary="@string/show_null_dates_first_pref_summary"
+        android:title="@string/show_null_dates_first_pref_title"
+        />
+
+    <CheckBoxPreference
         android:defaultValue="true"
         android:key="@string/append_tasks_at_end"
         android:summary="@string/append_tasks_at_end_summary"

--- a/app/src/test/java/nl/mpcjanssen/simpletask/task/BugsTest.kt
+++ b/app/src/test/java/nl/mpcjanssen/simpletask/task/BugsTest.kt
@@ -23,7 +23,7 @@ class BugsTest : TestCase() {
     fun testActiveSortNullCrash() {
         val opt = FilterOptions(luaModule = "test")
         val f = ActiveFilter(opt)
-        val mc = MultiComparator(f.getSort(null), todayAsString, true, false)
+        val mc = MultiComparator(f.getSort(null), todayAsString, true, false, false)
         Assert.assertNotNull(mc)
     }
 


### PR DESCRIPTION
Currently, tasks with no due dates appear last, at the bottom of the todo list.

I prefer to have tasks with no due dates appear first, at the top of the todo list. This is useful when I want to create (e.g.) a quick list of things to do today. Having to enter today's date for every task is cumbersome.

I don't know if this is a useful or desirable feature. If it is not, just let me know and I'll close the PR.
