### PR TITLE
Persistence

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
@@ -119,7 +119,7 @@ class AddTask : ThemedActionBarActivity() {
                 }
                 textInputField.setRawInputType(inputFlags)
                 textInputField.imeOptions = EditorInfo.IME_ACTION_NEXT
-                textInputField.setOnEditorActionListener { textView, actionId, keyEvent ->
+                textInputField.setOnEditorActionListener { _, actionId, keyEvent ->
                     val hardwareEnterUp = keyEvent != null &&
                             keyEvent.action == KeyEvent.ACTION_UP &&
                             keyEvent.keyCode == KeyEvent.KEYCODE_ENTER
@@ -337,7 +337,7 @@ class AddTask : ThemedActionBarActivity() {
                      * issue. The date is just replaced twice
                      */
                     val today = DateTime.today(TimeZone.getDefault())
-                    val dialog = DatePickerDialog(this@AddTask, DatePickerDialog.OnDateSetListener { datePicker, year, month, day ->
+                    val dialog = DatePickerDialog(this@AddTask, DatePickerDialog.OnDateSetListener { _, year, month, day ->
                         val date = DateTime.forDateOnly(year, month + 1, day)
                         insertDateAtSelection(dateType, date)
                     },
@@ -405,7 +405,7 @@ class AddTask : ThemedActionBarActivity() {
 
         initListViewSelection(lv, lvAdapter, task.tags)
 
-        builder.setPositiveButton(R.string.ok) { dialog, which ->
+        builder.setPositiveButton(R.string.ok) { _, _ ->
             val newText = ed.text.toString()
 
             for (i in 0..lvAdapter.count - 1) {
@@ -428,7 +428,7 @@ class AddTask : ThemedActionBarActivity() {
             }
             textInputField.setText(tasks.joinToString("\n") { it.text })
         }
-        builder.setNegativeButton(R.string.cancel) { dialog, id -> }
+        builder.setNegativeButton(R.string.cancel) { _, _ -> }
         // Create the AlertDialog
         val dialog = builder.create()
         dialog.setTitle(Config.tagTerm)
@@ -441,7 +441,7 @@ class AddTask : ThemedActionBarActivity() {
         val priorityCodes = priorities.mapTo(ArrayList<String>()) { it.code }
 
         builder.setItems(priorityCodes.toArray<String>(arrayOfNulls<String>(priorityCodes.size))
-        ) { arg0, which -> replacePriority(priorities[which].code) }
+        ) { _, which -> replacePriority(priorities[which].code) }
 
         // Create the AlertDialog
         val dialog = builder.create()
@@ -485,7 +485,7 @@ class AddTask : ThemedActionBarActivity() {
 
         initListViewSelection(lv, lvAdapter, task.lists)
 
-        builder.setPositiveButton(R.string.ok) { dialog, which ->
+        builder.setPositiveButton(R.string.ok) { _, _ ->
             for (i in 0..lvAdapter.count - 1) {
                 val list = lvAdapter.getItem(i)
                 if (lv.isItemChecked(i)) {
@@ -505,7 +505,7 @@ class AddTask : ThemedActionBarActivity() {
             }
             textInputField.setText(tasks.joinToString("\n") { it.text })
         }
-        builder.setNegativeButton(R.string.cancel) { dialog, id -> }
+        builder.setNegativeButton(R.string.cancel) { _, _ -> }
         // Create the AlertDialog
         val dialog = builder.create()
         dialog.setTitle(Config.listTerm)

--- a/app/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
@@ -350,7 +350,7 @@ class FilterActivity : ThemedNoActionBarActivity() {
         alert.setView(input)
         input.setText(name)
 
-        alert.setPositiveButton("Ok") { dialog, whichButton ->
+        alert.setPositiveButton("Ok") { _, _ ->
             val value = input.text.toString()
             if (value == "") {
                 showToastShort(applicationContext, R.string.widget_name_empty)
@@ -359,7 +359,7 @@ class FilterActivity : ThemedNoActionBarActivity() {
             }
         }
 
-        alert.setNegativeButton("Cancel") { dialog, whichButton -> }
+        alert.setNegativeButton("Cancel") { _, _ -> }
 
         alert.show()
 

--- a/app/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
@@ -28,6 +28,7 @@ class FilterActivity : ThemedNoActionBarActivity() {
 
     internal var asWidgetConfigure = false
     internal var asWidgetReConfigure = false
+    internal var queryId: String? = null
     internal lateinit var mFilter: Query
 
     internal lateinit var m_app: TodoApplication
@@ -67,6 +68,8 @@ class FilterActivity : ThemedNoActionBarActivity() {
             asWidgetConfigure = getIntent().action == AppWidgetManager.ACTION_APPWIDGET_CONFIGURE
             environment = "widget" + getIntent().getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 0).toString()
         }
+
+        queryId = intent.getStringExtra(SavedQuery.EXTRA_ID)
 
         mFilter = Query(luaModule = environment)
         val context = applicationContext
@@ -194,8 +197,13 @@ class FilterActivity : ThemedNoActionBarActivity() {
                 finish()
                 return true
             }
-            R.id.menu_filter_action ->
-                if (asWidgetConfigure) {
+            R.id.menu_filter_action -> {
+                val qId = queryId
+                if (qId != null) {
+                    updateFilterFromFragments()
+                    SavedQuery(qId, mFilter).save()
+                    finish()
+                } else if (asWidgetConfigure) {
                     askWidgetName()
                 } else if (asWidgetReConfigure) {
                     updateWidget()
@@ -203,6 +211,7 @@ class FilterActivity : ThemedNoActionBarActivity() {
                 } else {
                     applyFilter()
                 }
+            }
             R.id.menu_filter_load_script -> openScript { contents ->
                 runOnMainThread(
                         Runnable { setScript(contents) })

--- a/app/src/main/java/nl/mpcjanssen/simpletask/FilterSortFragment.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/FilterSortFragment.kt
@@ -112,7 +112,7 @@ class FilterSortFragment : Fragment() {
 
         adapter = SortItemAdapter(activity, R.layout.sort_list_item, R.id.text, adapterList)
         lv!!.adapter = adapter
-        lv!!.onItemClickListener = AdapterView.OnItemClickListener { parent, view, position, id ->
+        lv!!.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
             var direction = directions[position]
             if (direction == Query.REVERSED_SORT) {
                 direction = Query.NORMAL_SORT

--- a/app/src/main/java/nl/mpcjanssen/simpletask/MainFilter.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/MainFilter.kt
@@ -1,3 +1,0 @@
-package nl.mpcjanssen.simpletask
-
-var mainFilter = Query(luaModule = "mainui", showSelected = true)

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Query.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Query.kt
@@ -197,21 +197,21 @@ class Query(
         return sorts
     }
 
-    fun saveInIntent(target: Intent?) {
-        if (target != null) {
-            val json = this.saveInJSON()
-            target.putExtra(INTENT_JSON, json.toString(2))
+    private inline val json: JSONObject get() = this.saveInJSON()
+
+    fun saveInIntent(target: Intent?): Intent? {
+        return target?.apply {
+            putExtra(INTENT_JSON, json.toString(2))
         }
     }
 
     fun saveInPrefs(prefs: SharedPreferences?) {
         if (prefs != null) {
-            val json = this.saveInJSON()
             prefs.edit().putString(INTENT_JSON, json.toString(2)).commit()
         }
     }
 
-    fun clear() {
+    fun clear(): Query {
         priorities = ArrayList<Priority>()
         contexts = ArrayList<String>()
         projects = ArrayList<String>()
@@ -220,6 +220,7 @@ class Query(
         prioritiesNot = false
         contextsNot = false
         useScript = false
+        return this
     }
 
     fun initInterpreter() {

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Query.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Query.kt
@@ -19,7 +19,7 @@ class Query(
         val luaModule: String,
         val showSelected: Boolean = false
 ) {
-    private val log: Logger
+    private val log: Logger = Logger
     var priorities = ArrayList<Priority>()
     var contexts = ArrayList<String>()
     var projects = ArrayList<String>()
@@ -44,10 +44,6 @@ class Query(
     }
 
     var name: String? = null
-
-    init {
-        log = Logger
-    }
 
     val prefill
         get() : String {
@@ -80,14 +76,14 @@ class Query(
         }
     }
 
-    fun initFromJSON(json: JSONObject?) {
+    fun initFromJSON(json: JSONObject?): Query {
         val prios: String?
         val projects: String?
         val contexts: String?
         val sorts: String?
 
         if (json == null) {
-            return
+            return this
         }
         name = json.optString(INTENT_TITLE, "No title")
         prios = json.optString(INTENT_PRIORITIES_FILTER)
@@ -130,6 +126,7 @@ class Query(
             this.contexts = ArrayList(Arrays.asList(*contexts.split(INTENT_EXTRA_DELIMITERS.toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()))
         }
         initInterpreter()
+        return this
     }
 
     fun hasFilter(): Boolean {
@@ -355,7 +352,7 @@ class Query(
         const val INTENT_EXTRA_DELIMITERS = "\n|,"
     }
 
-    fun initFromIntent(intent: Intent) {
+    fun initFromIntent(intent: Intent): Query {
         if (intent.hasExtra(INTENT_JSON)) {
             val jsonFromIntent = intent.getStringExtra(INTENT_JSON)
             initFromJSON(JSONObject(jsonFromIntent))
@@ -407,9 +404,10 @@ class Query(
                 this.contexts = ArrayList(Arrays.asList(*contexts.split(INTENT_EXTRA_DELIMITERS.toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()))
             }
         }
+        return this
     }
 
-    fun initFromPrefs(prefs: SharedPreferences) {
+    fun initFromPrefs(prefs: SharedPreferences): Query {
         val jsonFromPref = prefs.getString(INTENT_JSON, null)
         if (jsonFromPref != null) {
             initFromJSON(JSONObject(jsonFromPref))
@@ -436,6 +434,7 @@ class Query(
             script = prefs.getString(INTENT_SCRIPT_FILTER, null)
             scriptTestTask = prefs.getString(INTENT_SCRIPT_TEST_TASK_FILTER, null)
         }
+        return this
     }
 
 }

--- a/app/src/main/java/nl/mpcjanssen/simpletask/SavedQuery.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/SavedQuery.kt
@@ -71,5 +71,6 @@ class SavedQuery(
         private inline val context get() = TodoApplication.app
 
         private const val ID_PREFIX: String = "filter_"
+        const val EXTRA_ID: String = "filterid"
     }
 }

--- a/app/src/main/java/nl/mpcjanssen/simpletask/SavedQuery.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/SavedQuery.kt
@@ -14,7 +14,7 @@ import java.io.File
 
 class SavedQuery(
         val id: String = nextId(),
-        val query: Query = savedQuery(id)
+        var query: Query = savedQuery(id)
 ) {
     val name: String get() = query.name ?: ""
 

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -297,10 +297,9 @@ class Simpletask : ThemedNoActionBarActivity() {
         }
 
         // Show search or filter results
-        queryId = null
         val intent = intent
         if (Constants.INTENT_START_FILTER == intent.action) {
-            activeQuery.initFromIntent(intent)
+            clearFilter()
             log.info(TAG, "handleIntent")
             val extras = intent.extras
             if (extras != null) {
@@ -316,11 +315,11 @@ class Simpletask : ThemedNoActionBarActivity() {
 
             }
             log.info(TAG, "handleIntent: saving filter in prefs")
-            activeQuery.saveInPrefs(Config.prefs)
+            activeQuery = activeQuery.initFromIntent(intent)
         } else {
             // Set previous filters and sort
             log.info(TAG, "handleIntent: from m_prefs state")
-            activeQuery.initFromPrefs(Config.prefs)
+            tempQuery.initFromPrefs(Config.prefs)
         }
 
         val adapter = m_adapter ?: TaskAdapter(layoutInflater)
@@ -1133,6 +1132,7 @@ class Simpletask : ThemedNoActionBarActivity() {
     fun startFilterActivity() {
         val i = Intent(this, FilterActivity::class.java)
         activeQuery.saveInIntent(i)
+        i.putExtra(SavedQuery.EXTRA_ID, queryId)
         startActivity(i)
     }
 

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -373,7 +373,9 @@ class Simpletask : ThemedNoActionBarActivity() {
         TodoList.todoQueue("Update filter bar") {
             runOnUiThread {
                 val total = TodoList.getTaskCount()
-                filter_text.text = activeQuery.getTitle(
+                filter_text.text = queryId?.let {
+                    activeQuery.name // TODO: Improve this string
+                } ?: activeQuery.getTitle(
                         count,
                         total,
                         getText(R.string.priority_prompt),

--- a/app/src/main/java/nl/mpcjanssen/simpletask/adapters/ItemDialogAdapter.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/adapters/ItemDialogAdapter.kt
@@ -66,7 +66,7 @@ class ItemDialogAdapter// Provide a suitable constructor (depends on the kind of
         holder.mCheckBox.text = viewItem
         holder.mCheckBox.setIndeterminateUsed(initialState[adapterPosition]==null)
         holder.mCheckBox.state = currentState[adapterPosition]
-        holder.mCheckBox.setOnStateChangedListener { indeterminateCheckBox, b ->
+        holder.mCheckBox.setOnStateChangedListener { _, b ->
             Logger.info("ItemAdapter", "state chaged $position:$viewItem, new state: $b")
             currentState[adapterPosition] = b
         }

--- a/app/src/main/java/nl/mpcjanssen/simpletask/util/Util.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/util/Util.kt
@@ -322,7 +322,7 @@ fun createDeferDialog(act: Activity, titleId: Int, listener: InputDialogListener
 
     val builder = AlertDialog.Builder(act)
     builder.setTitle(titleId)
-    builder.setItems(keys) { dialog, whichButton ->
+    builder.setItems(keys) { _, whichButton ->
         val which = whichButton
         val selected = values[which]
         listener.onClick(selected)


### PR DESCRIPTION
This PR aims to add the concept of an active query. That means:

- [x] The name of the active query will be shown in the filter bar, if it is saved.
- [x] Any changes made from the FilterActivity will automatically be saved in the active query, so they will persist even if I switch to another filter and back.
    - [x] Changes made in the quick filter (left) drawer will behave the same way, for now (I will change this behavior in a future PR which separates the quick filter from the active query)
- [x] The X in the filter bar will clear the active query. When there is no active query, changes made in the FilterActivity will not be persisted if I load a different filter.