### PR TITLE
Refactor Priority.kt and prio dialog bugfix

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
@@ -144,7 +144,7 @@ data class AppWidgetRemoteViewsFactory(val intent: Intent) : RemoteViewsService.
             else -> prioColor = ContextCompat.getColor(TodoApplication.app, R.color.gray67)
         }
         if (prioColor != 0) {
-            setColor(ss, prioColor, task.priority.inFileFormat())
+            setColor(ss, prioColor, task.priority.fileFormat)
         }
         if (task.isCompleted()) {
             ss.setSpan(StrikethroughSpan(), 0, ss.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/app/src/main/java/nl/mpcjanssen/simpletask/MultiComparator.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/MultiComparator.kt
@@ -41,14 +41,7 @@ class MultiComparator(sorts: ArrayList<String>, today: String, caseSensitve: Boo
                 } else {
                     { it -> it.showParts(TToken.TEXT).toLowerCase(Locale.getDefault()) }
                 }
-                "by_prio" -> comp = {
-                    val prio = it.priority
-                    if (prio == Priority.NONE) {
-                        "ZZZZ"
-                    } else {
-                        prio.code
-                    }
-                }
+                "by_prio" -> comp = { it.priority }
                 "completed" -> comp = { it.isCompleted() }
                 "by_creation_date" -> comp = { it.createDate ?: last_date }
                 "in_future" -> comp = { it.inFuture(today) }

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -628,13 +628,14 @@ class Simpletask : ThemedNoActionBarActivity() {
     }
 
     private fun prioritizeTasks(tasks: List<Task>) {
-        val strings = Priority.rangeInCode(Priority.NONE, Priority.Z)
-        val priorityArr = strings.toTypedArray()
+        val priorityArr = Priority.codes.toTypedArray()
 
-        var priorityIdx = 0
-        if (tasks.size == 1) {
-            priorityIdx = strings.indexOf(tasks[0].priority.code)
-        }
+        val first = tasks[0].priority.code
+
+        val priorityIdx = if (tasks.all { it.priority.code == first }) {
+            priorityArr.indexOf(first)
+        } else 0
+
         val builder = AlertDialog.Builder(this)
         builder.setTitle(R.string.select_priority)
         builder.setSingleChoiceItems(priorityArr, priorityIdx, { dialog, which ->
@@ -1235,7 +1236,7 @@ class Simpletask : ThemedNoActionBarActivity() {
                 Priority.D -> priorityColor = ContextCompat.getColor(m_app, R.color.simple_blue_dark)
                 else -> priorityColor = ContextCompat.getColor(m_app, R.color.gray67)
             }
-            setColor(ss, priorityColor, priority.inFileFormat())
+            setColor(ss, priorityColor, priority.fileFormat)
             val completed = task.isCompleted()
 
             taskAge.textSize = textSize * Config.dateBarRelativeSize

--- a/app/src/main/java/nl/mpcjanssen/simpletask/task/Priority.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/task/Priority.kt
@@ -26,89 +26,38 @@ package nl.mpcjanssen.simpletask.task
 
 import java.util.*
 
-enum class Priority constructor(val code: String, private val listFormat: String, private val detailFormat: String,
-                                        private val fileFormat: String) {
-    NONE("-", "   ", "", ""), A("A", "A", "A", "(A)"), B("B", "B", "B", "(B)"), C("C", "C", "C", "(C)"), D("D", "D", "D", "(D)"), E("E", "E", "E", "(E)"), F("F", "F", "F", "(F)"), G("G", "G", "G", "(G)"), H("H", "H", "H", "(H)"), I("I", "I", "I", "(I)"), J("J", "J", "J", "(J)"), K("K", "K", "K", "(K)"), L("L", "L", "L", "(L)"), M("M", "M", "M", "(M)"), N("N", "N", "N", "(N)"), O("O", "O", "O", "(O)"), P("P", "P", "P", "(P)"), Q("Q", "Q", "Q", "(Q)"), R("R", "R", "R", "(R)"), S("S", "S", "S", "(S)"), T("T", "T", "T", "(T)"), U("U", "U", "U", "(U)"), V("V", "V", "V", "(V)"), W("W", "W", "W", "(W)"), X("X", "X", "X", "(X)"), Y("Y", "Y", "Y", "(Y)"), Z("Z", "Z", "Z", "(Z)");
+enum class Priority {
 
-    fun inListFormat(): String {
-        return listFormat
-    }
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+    NONE {
+        override val code: String = "-"
+        override val fileFormat: String = ""
+    };
 
-    fun inDetailFormat(): String {
-        return detailFormat
-    }
-
-    fun inFileFormat(): String {
-        return fileFormat
-    }
+    open val code: String = name
+    open val fileFormat: String = "($name)"
 
     companion object {
 
-        private fun reverseValues(): Array<Priority> {
-            val values = Priority.values()
-            return values.reversed().toTypedArray()
-        }
-
-        fun range(p1: Priority, p2: Priority): List<Priority> {
-            val priorities = ArrayList<Priority>()
-            var add = false
-
-            for (p in if (p1.ordinal < p2.ordinal)
-                Priority.values()
-            else
-                Priority.reverseValues()) {
-                if (p == p1) {
-                    add = true
-                }
-                if (add) {
-                    priorities.add(p)
-                }
-                if (p == p2) {
-                    break
-                }
-            }
-            return priorities
-        }
-
-        fun rangeInCode(p1: Priority, p2: Priority): List<String> {
-            val priorities = Priority.range(p1, p2)
-            val result = ArrayList<String>(priorities.size)
-            for (p in priorities) {
-                result.add(p.code)
-            }
-            return result
-        }
+        val codes: List<String>
+            get() = values().map { it.code }.sorted()
 
         fun inCode(priorities: List<Priority>): ArrayList<String> {
-            val strings = ArrayList<String>()
-            for (p in priorities) {
-                strings.add(p.code)
-            }
-            return strings
+            return ArrayList<String>(priorities.map { it.code })
         }
 
-        fun toPriority(codes: List<String>?): ArrayList<Priority> {
-            val priorities = ArrayList<Priority>()
-            if (codes == null) {
-                return ArrayList()
-            }
-            for (code in codes) {
-                priorities.add(Priority.toPriority(code))
-            }
-            return priorities
+        fun toPriority(codes: List<String>): ArrayList<Priority> {
+            return ArrayList<Priority>(codes.map { toPriority(it) })
         }
 
         fun toPriority(s: String?): Priority {
-            if (s == null) {
+            val upper = s?.toUpperCase(Locale.US) ?: return NONE
+            try {
+                return valueOf(upper)
+            }
+            catch (e: IllegalArgumentException) {
                 return NONE
             }
-
-            for (p in Priority.values()) {
-                if (p.code == s.toUpperCase(Locale.US)) {
-                    return p
-                }
-            }
-            return NONE
         }
     }
 

--- a/app/src/main/java/nl/mpcjanssen/simpletask/task/Task.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/task/Task.kt
@@ -142,9 +142,9 @@ class Task(text: String, defaultPrependedDate: String? = null) {
             if (prio == Priority.NONE) {
                 tokens = tokens.filter { it !is PriorityToken }
             } else if (tokens.any { it is PriorityToken }) {
-                upsertToken(PriorityToken(prio.inFileFormat()))
+                upsertToken(PriorityToken(prio.fileFormat))
             } else {
-                tokens = listOf(PriorityToken(prio.inFileFormat())) + tokens
+                tokens = listOf(PriorityToken(prio.fileFormat)) + tokens
             }
         }
 


### PR DESCRIPTION
Refactor to remove unused code, and take advantage of stuff kotlin gives us in enums.

Bugfix: Currently, if you select multiple tasks with Priority A and try
to change their priority, the dialog will be pre-filled with '-' as
their priority. This makes it so 'A' will be pre-filled. If the tasks
have different priorities, the pre-fill will still be '-'.