### PR TITLE
always initialize queries in the constructor

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/AddTask.kt
@@ -101,9 +101,7 @@ class AddTask : ThemedActionBarActivity() {
                 } else if (intent.hasExtra(Constants.EXTRA_PREFILL_TEXT)) {
                     intent.getStringExtra(Constants.EXTRA_PREFILL_TEXT)
                 } else if (intent.hasExtra(Query.INTENT_JSON)) {
-                    val currentFilter = Query(luaModule = "from_intent")
-                    currentFilter.initFromIntent(intent)
-                    currentFilter.prefill
+                    Query(intent, luaModule = "from_intent").prefill
                 } else {
                     ""
                 }

--- a/app/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/AppWidgetService.kt
@@ -49,9 +49,8 @@ data class AppWidgetRemoteViewsFactory(val intent: Intent) : RemoteViewsService.
     fun updateFilter(): Query {
 	    log.debug (TAG, "Getting applyFilter from preferences for widget $widgetId")
 	    val preferences = TodoApplication.app.getSharedPreferences("" + widgetId, 0)
-        val filter = Query(luaModule = moduleName())
-        filter.initFromPrefs(preferences)
-        log.debug(TAG, "Retrieved widget $widgetId applyFilter")
+        val filter = Query(preferences, luaModule = moduleName())
+        log.debug(TAG, "Retrieved widget $widgetId query")
 
         return filter
     }

--- a/app/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/FilterActivity.kt
@@ -69,22 +69,20 @@ class FilterActivity : ThemedNoActionBarActivity() {
         }
 
 
-        mFilter = Query(luaModule = environment)
         val context = applicationContext
 
-        if (asWidgetConfigure) {
-            if (intent.getBooleanExtra(Constants.EXTRA_WIDGET_RECONFIGURE, false)) {
-                asWidgetReConfigure = true
-                asWidgetConfigure = false
-                setTitle(R.string.config_widget)
-                val preferences = context.getSharedPreferences("" + intent.getIntExtra(Constants.EXTRA_WIDGET_ID, -1), Context.MODE_PRIVATE)
-                mFilter.initFromPrefs(preferences)
-            } else {
-                setTitle(R.string.create_widget)
-                mFilter.initFromPrefs(prefs)
-            }
+        if (!asWidgetConfigure) {
+            mFilter = Query(intent, luaModule = environment)
+        } else if (intent.getBooleanExtra(Constants.EXTRA_WIDGET_RECONFIGURE, false)) {
+            asWidgetReConfigure = true
+            asWidgetConfigure = false
+            setTitle(R.string.config_widget)
+            val prefsName = intent.getIntExtra(Constants.EXTRA_WIDGET_ID, -1).toString()
+            val preferences = context.getSharedPreferences(prefsName , Context.MODE_PRIVATE)
+            mFilter = Query(preferences, luaModule = environment)
         } else {
-            mFilter.initFromIntent(intent)
+            setTitle(R.string.create_widget)
+            mFilter = Query(prefs, luaModule = environment)
         }
 
         pagerAdapter = ScreenSlidePagerAdapter(supportFragmentManager)

--- a/app/src/main/java/nl/mpcjanssen/simpletask/MyAppWidgetProvider.java
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/MyAppWidgetProvider.java
@@ -26,8 +26,7 @@ public class MyAppWidgetProvider extends AppWidgetProvider {
 
     private static void putFilterExtras(Intent target, @NonNull SharedPreferences preferences, int widgetId) {
         // log.debug(tag, "putFilter extras  for appwidget " + widgetId);
-        Query filter = new Query("widget" + widgetId);
-        filter.initFromPrefs(preferences);
+        Query filter = new Query(preferences, "widget" + widgetId);
         filter.saveInIntent(target);
     }
 

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -263,7 +263,7 @@ class Simpletask : ThemedNoActionBarActivity() {
                     log.debug(TAG, "$key $debugString")
                 }
             }
-            val newQuery = Query("mainui").initFromIntent(currentIntent)
+            val newQuery = Query(currentIntent, "mainui")
             Config.mainQuery = newQuery
             intent = newQuery.saveInIntent(intent)
             newQuery
@@ -935,10 +935,9 @@ class Simpletask : ThemedNoActionBarActivity() {
                 FileStore.readFile(importFile.canonicalPath) { contents ->
                     val jsonFilters = JSONObject(contents)
                     jsonFilters.keys().forEach { name ->
-                        val newQuery = Query(luaModule = "mainui")
-                        newQuery.initFromJSON(jsonFilters.getJSONObject(name))
+                        val json = jsonFilters.getJSONObject(name)
+                        val newQuery = Query(json, luaModule = "mainui")
                         QueryStore.save(newQuery, name)
-
                     }
                     localBroadcastManager?.sendBroadcast(Intent(Constants.BROADCAST_UPDATE_UI))
                     showToastShort(this, R.string.saved_filters_imported) }
@@ -956,7 +955,6 @@ class Simpletask : ThemedNoActionBarActivity() {
             QueryStore.get(it)
         }
         val jsonFilters = queries.fold(JSONObject()) { acc, query ->
-
             acc.put(query.name, query.query.saveInJSON())
         }
         val r = Runnable {

--- a/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
@@ -278,11 +278,7 @@ object Config : Preferences(TodoApplication.app) {
     }
 
     var mainQuery: Query
-        get()  {
-            val q = Query(luaModule = "mainui")
-            q.initFromPrefs(Config.prefs)
-            return q
-        }
+        get() = Query(this.prefs, luaModule = "mainui")
         set(value) {
             // Update the intent so we wont get the old applyFilter after
             // switching back to app later. Fixes [1c5271ee2e]


### PR DESCRIPTION
This is just a bit of code cleanup. I…

- Made `initFromJSON`, `initFromPrefs`, and `initFromIntent` private
- Added constructors which take a `jsonObject`, `sharedPreferences`, or `intent` and call the respective `initFrom`
- Fixed compilation errors

This is a step towards eliminating state from queries, which we could eventually change to be a simple, immutable `data class`. It also makes it impossible to create bugs where we use a query before it's initialized.

Granted, it also removes the flexibility to initialize a query after it's created, but we're currently not doing that anywhere, and it's easy enough to make the `initFrom` functions public again if we need them later.