### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: "Checkout"
       uses: actions/checkout@v1
-    - name: "Setup android"
-      uses: msfjarvis/setup-android@1.0
     - name: "Run build"  
       run: ./gradlew assembleCloudless assembleNextcloud
     - name: "Save output artifacts"


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.
﻿