### PR TITLE
remove trailing WhiteSpaceToken when constructing a Task

### DIFF
--- a/app/src/main/java/nl/mpcjanssen/simpletask/task/Task.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/task/Task.kt
@@ -465,8 +465,24 @@ class Task(text: String, defaultPrependedDate: String? = null) {
                         tokens.add(TextToken(lexeme))
                     }
                 }
-                return tokens
+
+                return removeTrailingWhiteSpaceToken(tokens);
             }
+        }
+
+        private fun removeTrailingWhiteSpaceToken(tokens: ArrayList<TToken>): ArrayList<TToken> {
+            var endIndex = tokens.lastIndex;
+            for (i in tokens.lastIndex downTo 0) {
+                if(tokens[i] is WhiteSpaceToken) {
+                    endIndex = i-1;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return tokens.slice(0..endIndex) as ArrayList<TToken>;
         }
     }
 }


### PR DESCRIPTION
I added a function to remove trailing WhiteSpaceTokens when constructing a Task. This fixes #1103.