### PR TITLE
Explanation for GTD abbreviation added (DE)

### DIFF
--- a/app/src/main/assets/index.de.md
+++ b/app/src/main/assets/index.de.md
@@ -3,7 +3,7 @@ Simpletask
 
 See in [English](./index.en.md), Ver en [Español](./index.es.md)
 
-[Simpletask](https://github.com/mpcjanssen/simpletask-android) basiert auf dem brillanten [todo.txt](http://todotxt.com) von [Gina Trapani](http://ginatrapani.org/). Ziel der App ist es, ein Werkzeug für GTD zur Verfügung zu stellen und sich auf die hierfür wesentlichen Funktionen zu konzentrieren. Auch wenn Simpletask durch eine Reihe von Optionen sehr flexibel angepasst werden kann, sind die Voreinstellungen so gewählt, dass sie im Normalfall unverändert bleiben können. 
+[Simpletask](https://github.com/mpcjanssen/simpletask-android) basiert auf dem brillanten [todo.txt](http://todotxt.com) von [Gina Trapani](http://ginatrapani.org/). Ziel der App ist es, ein Werkzeug für ['Getting Things Done'](https://gettingthingsdone.com/) (GTD) zur Verfügung zu stellen und sich auf die hierfür wesentlichen Funktionen zu konzentrieren. Auch wenn Simpletask durch eine Reihe von Optionen sehr flexibel angepasst werden kann, sind die Voreinstellungen so gewählt, dass sie im Normalfall unverändert bleiben können. 
 
 [Simpletask](https://github.com/mpcjanssen/simpletask-android) kann als sehr einfache Aufgabenliste oder als komplexer Action Manager für GTD oder [Manage Your Now](./MYN.de.md) verwendet werden.
 
@@ -27,5 +27,5 @@ weitere Hilfekapitel im App-Menü oder unter folgenden Links:
 - [Todo.txt Erweiterungen](./extensions.de.md)
 - [Listen und Tags](./listsandtags.de.md) Warum verwendet Simpletask die Begriffe "Liste" und "Tag" statt "Kontext" und "Projekt" aus todo.txt?
 - [Definierte Intents](./intents.de.md) Android Intents, die für die Automatisierung von Simpletask verwendet werden können.
-- [1MTD/MYN mit Simpletask](./MYN.de.md)
+- Simpletask einsetzen für 'The One Minute To-Do List' oder 'Master Your Now' [1MTD/MYN](./MYN.de.md)
 - [Skripten mit Lua](./script.de.md)


### PR DESCRIPTION
DE + EN fine now. ES already contained explanations.