### PR TITLE
Fix bug where notifications can disappear/lose association with task

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -203,6 +203,9 @@ You should have received a copy of the GNU General Public License along with Sim
         <service
             android:name=".MarkTaskDone"
             />
+        <service
+            android:name=".NotificationService"
+            />
         <receiver android:name="nl.mpcjanssen.simpletask.AlarmReceiver"/>
         <uses-library
             android:name="com.sec.android.app.multiwindow"

--- a/app/src/main/java/nl/mpcjanssen/simpletask/NotificationService.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/NotificationService.kt
@@ -1,0 +1,93 @@
+package nl.mpcjanssen.simpletask
+
+import android.app.Activity
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import nl.mpcjanssen.simpletask.task.Task
+import nl.mpcjanssen.simpletask.task.TodoList
+import nl.mpcjanssen.simpletask.util.Config
+import nl.mpcjanssen.simpletask.util.showToastShort
+import nl.mpcjanssen.simpletask.util.todayAsString
+import nl.mpcjanssen.simpletask.util.broadcastTasklistChanged
+import java.io.IOException
+import android.app.Service
+import android.app.NotificationManager
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+
+class NotificationService : Service() {
+    public override fun onCreate() {
+        val builder = NotificationCompat.Builder(this, "pin-notifications")
+            .setSmallIcon(R.drawable.ic_done_white_24dp)
+            .setGroup("group")
+            .setGroupSummary(true)
+            .setOngoing(true)
+        startForeground(1, builder.build())
+    }
+
+    public override fun onStartCommand (intent: Intent, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        Log.d(TAG, "onStartCommand()")
+        val taskIds = intent.getStringArrayExtra(Constants.EXTRA_TASK_ID)
+        Log.d(TAG, "got taskIds from extras ${taskIds?.joinToString(",")}")
+        if (taskIds == null) {
+            Log.e(TAG, "Extra ${Constants.EXTRA_TASK_ID} not found in intent")
+            return START_STICKY_COMPATIBILITY
+        }
+        pinNotifications(taskIds)
+        return START_REDELIVER_INTENT
+    }
+
+    private fun pinNotifications(taskIds: Array<String>) {
+        for (id in taskIds) {
+            val task = TodoApplication.todoList.getTaskWithId(id)
+            if (task == null) {
+                Log.e(TAG, "Task with id '$id' not found in todo list")
+                continue
+            }
+            val taskIdHash = task.id.hashCode()
+            val editTaskIntent = Intent(this, AddTask::class.java).let {
+                it.putExtra(Constants.EXTRA_TASK_ID, task.id)
+                PendingIntent.getActivity(this, taskIdHash, it, PendingIntent.FLAG_IMMUTABLE)
+            }
+            val markDoneIntent = Intent(this, MarkTaskDone::class.java).let {
+                it.putExtra(Constants.EXTRA_TASK_ID, task.id)
+                PendingIntent.getService(this, taskIdHash, it, PendingIntent.FLAG_IMMUTABLE)
+            }
+            var builder = NotificationCompat.Builder(this, "pin-notifications")
+                .setSmallIcon(R.drawable.ic_done_white_24dp)
+                .setContentTitle(task.text)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(editTaskIntent)
+                .addAction(R.drawable.ic_done_white_24dp, getString(R.string.done), markDoneIntent)
+                .addExtras(Bundle().apply { putString(Constants.EXTRA_TASK_ID, task.id) })
+                .setGroup("group")
+
+            with(NotificationManagerCompat.from(this)) {
+                notify(taskIdHash, builder.build())
+            }
+            if (!TodoApplication.config.hasKeepSelection) {
+                TodoApplication.todoList.clearSelection()
+            }
+        }
+    }
+
+    public override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    companion object {
+        val TAG = "NotificationService"
+    
+        fun removeNotifications(taskIds: List<String>) {
+            taskIds.forEach{
+                TodoApplication.notificationManager.cancel(it.hashCode())
+            }
+        }
+    }
+}

--- a/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/Simpletask.kt
@@ -1120,31 +1120,10 @@ class Simpletask : ThemedNoActionBarActivity() {
     }
 
     private fun pinNotification(checkedTasks: List<Task>) {
-        for (task in checkedTasks) {
-            val taskIdHash = task.id.hashCode()
-            val editTaskIntent = Intent(this, AddTask::class.java).let {
-                it.putExtra(Constants.EXTRA_TASK_ID, task.id)
-                PendingIntent.getActivity(this, taskIdHash, it, PendingIntent.FLAG_IMMUTABLE)
-            }
-            val markDoneIntent = Intent(this, MarkTaskDone::class.java).let {
-                it.putExtra(Constants.EXTRA_TASK_ID, task.id)
-                PendingIntent.getService(this, taskIdHash, it, PendingIntent.FLAG_IMMUTABLE)
-            }
-            var builder = NotificationCompat.Builder(this, "pin-notifications")
-                .setSmallIcon(R.drawable.ic_done_white_24dp)
-                .setContentTitle(task.text)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setContentIntent(editTaskIntent)
-                .addAction(R.drawable.ic_done_white_24dp, getString(R.string.done), markDoneIntent)
-                .addExtras(Bundle().apply { putString(Constants.EXTRA_TASK_ID, task.id) })
-
-            with(NotificationManagerCompat.from(this)) {
-                notify(taskIdHash, builder.build())
-            }
-            if (!TodoApplication.config.hasKeepSelection) {
-                TodoApplication.todoList.clearSelection()
-            }
-        }
+        val taskIds = checkedTasks.map { it.id }.toTypedArray()
+        val intent = Intent(this, NotificationService::class.java)
+        intent.putExtra(Constants.EXTRA_TASK_ID, taskIds)
+        startForegroundService(intent)
     }
 
     private inner class UiHandler () {

--- a/app/src/main/java/nl/mpcjanssen/simpletask/dao/TaskIdDao.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/dao/TaskIdDao.kt
@@ -1,0 +1,36 @@
+package nl.mpcjanssen.simpletask.dao
+
+import nl.mpcjanssen.simpletask.TodoApplication
+import nl.mpcjanssen.simpletask.task.Task
+import android.content.Context.MODE_PRIVATE
+
+object TaskIdDao {
+    val sharedPrefs = TodoApplication.app.getSharedPreferences("todolist", MODE_PRIVATE)
+    val editor = sharedPrefs.edit()
+
+    fun get(taskText: String): String? {
+        return sharedPrefs.getString(taskText, null)
+    }
+
+    fun add(tasks: List<Task>) {
+        tasks.forEach {
+            editor.putString(it.text, it.id)
+        }
+        editor.apply()
+    }
+
+    fun add(task: Task) {
+        add(listOf(task))
+    }
+
+    fun remove(tasks: List<Task>) {
+        tasks.forEach {
+            editor.remove(it.text)
+        }
+        editor.apply()
+    }
+
+    fun remove(task: Task) {
+        remove(listOf(task))
+    }
+}

--- a/app/src/main/java/nl/mpcjanssen/simpletask/task/Task.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/task/Task.kt
@@ -4,7 +4,7 @@ import nl.mpcjanssen.simpletask.util.addInterval
 import java.util.*
 import java.util.regex.Pattern
 
-class Task(text: String, defaultPrependedDate: String? = null) {
+class Task(text: String, defaultPrependedDate: String? = null, val id: String = UUID.randomUUID().toString()) {
 
     var tokens: ArrayList<TToken>
 
@@ -21,6 +21,10 @@ class Task(text: String, defaultPrependedDate: String? = null) {
 
     fun update(rawText: String) {
         tokens = parse(rawText)
+    }
+
+    fun withId(id: String): Task {
+        return Task(text, id = id)
     }
 
     private inline fun <reified T> getFirstToken(): T? {
@@ -41,8 +45,6 @@ class Task(text: String, defaultPrependedDate: String? = null) {
         }
 
     }
-
-    var id: String = UUID.randomUUID().toString()
 
     val text: String
         get() {

--- a/app/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/task/TodoList.kt
@@ -10,6 +10,7 @@ import nl.mpcjanssen.simpletask.remote.FileStore
 
 import nl.mpcjanssen.simpletask.remote.IFileStore
 import nl.mpcjanssen.simpletask.util.*
+import nl.mpcjanssen.simpletask.dao.TaskIdDao
 import java.io.File
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
@@ -45,7 +46,7 @@ class TodoList(val config: Config) {
         } else {
             todoItems.addAll(0, updatedItems)
         }
-
+        TaskIdDao.add(items)
     }
 
     fun add(t: Task, atEnd: Boolean) {
@@ -57,7 +58,7 @@ class TodoList(val config: Config) {
         Log.d(tag, "Remove")
         pendingEdits.removeAll(tasks)
         todoItems.removeAll(tasks)
-
+        TaskIdDao.remove(tasks)
     }
 
 
@@ -160,10 +161,13 @@ class TodoList(val config: Config) {
         val smallestSize = org.zip(updated) { orgTask, updatedTask ->
             val idx = todoItems.indexOf(orgTask)
             if (idx != -1) {
-                updatedTask.id = orgTask.id
-                todoItems[idx] = updatedTask
+                val newTask = updatedTask.withId(orgTask.id)
+                todoItems[idx] = newTask
+                TaskIdDao.remove(orgTask)
+                TaskIdDao.add(newTask)
             } else {
                 todoItems.add(updatedTask)
+                TaskIdDao.add(updatedTask)
             }
             1
         }.size
@@ -263,7 +267,15 @@ class TodoList(val config: Config) {
             try {
                 val items = FileStore.loadTasksFromFile(file)
 
-                val newTodoItems = items.map { Task(it) }.toMutableList()
+                val newTodoItems = items.map { 
+                    val taskId = TaskIdDao.get(it)
+                    if (taskId == null) {
+                        val task = Task(it) 
+                        TaskIdDao.add(task)
+                        task
+                    }
+                    else Task(it, id = taskId)
+                }.toMutableList()
                 synchronized(todoItems) {
                     Log.d(tag, "Fill todolist with ${items.size} items")
                     todoItems = newTodoItems

--- a/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
+++ b/app/src/main/java/nl/mpcjanssen/simpletask/util/Config.kt
@@ -1,13 +1,16 @@
 package nl.mpcjanssen.simpletask.util
 
+import android.content.Context.MODE_PRIVATE
 import android.os.Build
 import android.os.Environment
+import android.preference.PreferenceManager
 import android.util.Log
 import androidx.annotation.RequiresApi
 import me.smichel.android.KPreferences.Preferences
 import nl.mpcjanssen.simpletask.*
 import nl.mpcjanssen.simpletask.remote.FileStore
 import nl.mpcjanssen.simpletask.task.Task
+import nl.mpcjanssen.simpletask.dao.TaskIdDao
 import org.json.JSONObject
 import java.io.File
 import java.util.*
@@ -229,7 +232,16 @@ class Config(app: TodoApplication) : Preferences(app) {
             val lines = it.lines()
             Log.i(TAG, "Getting ${lines.size} items todoList from cache")
             ArrayList<Task>().apply {
-                addAll(lines.map { line -> Task(line) })
+                addAll(lines.map { line -> 
+                    val taskId = TaskIdDao.get(line)
+                    if (taskId == null) {
+                        val task = Task(line) 
+                        TaskIdDao.add(task)
+                        task
+                    } else {
+                        Task(line, id = taskId)
+                    }
+                })
             }
         }
         set(items) {


### PR DESCRIPTION
Since adding the ability to pin tasks as notifications in #1170 I've found a couple issues with the current implementation. Namely:
- Sometimes pinned notifications will randomly disappear. It seems like this was caused by the app being restarted by the OS/crashing in the background as I could reproduce in an emulator by running `adb shell am force-stop nl.mpcjanssen.simpletask.debug`.

Solution: Create the notifications from a `Service` and call `startForeground`.

- If the todo list is modified outside of simpletask, the task IDs will change causing the notifications to lose their association with each task.

Solution: Make the task IDs persistent by storing them in `SharedPreferences`. 