### PR TITLE
Use okhttp 4.10.0-RC1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.8.1'
     def withoutJUnit = { exclude group: 'junit', module: 'junit' }
     // dokuwikiImplementation 'org.apache.xmlrpc:xmlrpc-client:3.1.3', withoutJUnit
-//    webdavImplementation 'com.squareup.okhttp3:okhttp:4.10.0-RC1'
+    webdavImplementation 'com.squareup.okhttp3:okhttp:4.10.0-RC1'
     webdavImplementation 'com.github.thegrizzlylabs:sardine-android:v0.8'
 
 //    webdavImplementation ('org.simpleframework:simple-xml:2.7.1')  {


### PR DESCRIPTION
Hi @mpcjanssen!

Back in 2020, I was having some trouble with a `stream was reset: NO_ERROR` error that was fixed by using `okhttp` version `4.10.0-RC1`. https://github.com/mpcjanssen/simpletask-android/issues/1099

It looks like a change was made a year ago to 'not vendor Sardine' which reverted okhttp back to `4.9.0`, and reintroduced the error. https://github.com/mpcjanssen/simpletask-android/commit/e10108322734df2bb222e83874e78542fbaddb09

Would it be possible to flip to `4.10.0-RC1` again?

For some reason, `4.10.0` is not working but `5.0.0-alpha.10` is. If a `5.0.0` version is ever released, there would be some hope to not use a RC version. If you want, I could instead try to upgrade the `okhttp` version in `sardine-android`.

Thanks!