### PR TITLE
Fix circleci error

### DIFF
--- a/app/src/nextcloud/java/nl/mpcjanssen/simpletask/remote/FileStore.kt
+++ b/app/src/nextcloud/java/nl/mpcjanssen/simpletask/remote/FileStore.kt
@@ -271,7 +271,7 @@ object FileStore : IFileStore {
                 if (remoteFile is RemoteFile) {
                     if (remoteFile.mimeType == "DIR") {
                         result.add(FileEntry(File(remoteFile.remotePath).name, true))
-                    } else if (!txtOnly || remoteFile.remotePath.lowercase(Locale.getDefault()).endsWith(".txt")) {
+                    } else if (!txtOnly || remoteFile.remotePath.toLowerCase(Locale.getDefault()).endsWith(".txt")) {
                         result.add(FileEntry(File(remoteFile.remotePath).name, false))
                     }
                 }


### PR DESCRIPTION
Fixes the circleci error caused by my pull request #1225.
Sorry, I'm new to Kotlin ...

I used `lowercase()` because Android Studio marked `toLowerCase()` as deprecated.
`lowercase()` is not experimental since Kotlin 1.5 - but the project uses 1.4.32.